### PR TITLE
Move extension method to main namespace

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -25,28 +25,45 @@ All notable changes to this project will be documented in this file.
 
 > ❗ Whilst in the beta phase, breaking changes will happen between "minor" releases. Because of this, patches and new features will happen at between "patch" releases.
 
+## [0.2.1-beta] - UNPUBLISHED
+
+<small>[Compare to previous release][comp:0.2.1-beta]</small>
+
+### Package: TopMarksDevelopment.ExpressionBuilder.Operations.* (All Operations)
+
+#### Changed
+
+-   Moved all extension methods from the `TopMarksDevelopment.ExpressionBuilder.Api` namespace to `TopMarksDevelopment.ExpressionBuilder`, for easier access _(not technically "breaking" as the main package is always required to operate)_
+
 ## [0.2.0-beta] - 2024-02-28
 
 <small>[Compare to previous release][comp:0.2.0-beta]</small>
 
-### Breaking Changes
+### Package: TopMarksDevelopment.ExpressionBuilder.Api
+
+#### Breaking Changes
 
 -   Moved the `Connector` and `Matches` enumerators from `TopMarksDevelopment.ExpressionBuilder.Api` to `TopMarksDevelopment.ExpressionBuilder`, for easier access
 
-### Fixes
+### Package: TopMarksDevelopment.ExpressionBuilder
 
-- Removed duplicated methods that we in both the `TopMarksDevelopment.ExpressionBuilder.Api` and `TopMarksDevelopment.ExpressionBuilder` namespaces. Preventing you from using an extension method if you use both namespaces
+#### Fixes
 
-### Changes
+-   Removed duplicated methods from `TopMarksDevelopment.ExpressionBuilder`, as they were already in the `TopMarksDevelopment.ExpressionBuilder.Api` namespace. This prevented you from using an `Add` extension method if you `use` both namespaces
 
-- Added GitHub `FUNDING.yml` to hopefully get some support/funding 😜
-- (Non-user facing) Updated the GitHub workflows to use the current versions of `checkout` and `setup-dotnet`
+### General changes (non-package related)
 
+#### Changes
+
+-   Added GitHub `FUNDING.yml` to hopefully get some support/funding 😜
+-   (Non-user facing) Updated the GitHub workflows to use the current versions of `checkout` and `setup-dotnet`
 
 ## [0.1.0-beta] - 2024-02-28
 
 **Initial release**
 
+[0.2.1-beta]: https://github.com/TopMarksDevelopment/Expression-Builder/releases/tag/v0.2.1-beta
+[comp:0.2.1-beta]: https://github.com/TopMarksDevelopment/Expression-Builder/compare/v0.2.0-beta...v0.2.1-beta
 [0.2.0-beta]: https://github.com/TopMarksDevelopment/Expression-Builder/releases/tag/v0.2.0-beta
 [comp:0.2.0-beta]: https://github.com/TopMarksDevelopment/Expression-Builder/compare/v0.1.0-beta...v0.2.0-beta
 [0.1.0-beta]: https://github.com/TopMarksDevelopment/Expression-Builder/releases/tag/v0.1.0-beta

--- a/Packages/Operations/Between/src/Extensions/IFilterAddExtensions.cs
+++ b/Packages/Operations/Between/src/Extensions/IFilterAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterBetweenExtensions
 {

--- a/Packages/Operations/Between/src/Extensions/IFilter_TClass_AddExtensions.cs
+++ b/Packages/Operations/Between/src/Extensions/IFilter_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilter_TClass_BetweenExtensions
 {

--- a/Packages/Operations/Between/src/Extensions/IFilterableAddExtensions.cs
+++ b/Packages/Operations/Between/src/Extensions/IFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterableBetweenExtensions
 {

--- a/Packages/Operations/Between/src/Extensions/IFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/Between/src/Extensions/IFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterable_TClass_BetweenExtensions
 {

--- a/Packages/Operations/Between/src/Extensions/IQueryFilterableAddExtensions.cs
+++ b/Packages/Operations/Between/src/Extensions/IQueryFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterableBetweenExtensions
 {

--- a/Packages/Operations/Between/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/Between/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterable_TClass_BetweenExtensions
 {

--- a/Packages/Operations/Between/tests/AllTests.cs
+++ b/Packages/Operations/Between/tests/AllTests.cs
@@ -2,7 +2,7 @@ namespace ExpressionBuilder.Tests;
 
 using System.Collections.Generic;
 using ExpressionBuilder.Tests.Models;
-using TopMarksDevelopment.ExpressionBuilder.Operations;
+using TopMarksDevelopment.ExpressionBuilder;
 
 public class AllTests
 {

--- a/Packages/Operations/BetweenExclusive/src/Extensions/IFilterAddExtensions.cs
+++ b/Packages/Operations/BetweenExclusive/src/Extensions/IFilterAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterBetweenExclusiveExtensions
 {

--- a/Packages/Operations/BetweenExclusive/src/Extensions/IFilter_TClass_AddExtensions.cs
+++ b/Packages/Operations/BetweenExclusive/src/Extensions/IFilter_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilter_TClass_BetweenExclusiveExtensions
 {

--- a/Packages/Operations/BetweenExclusive/src/Extensions/IFilterableAddExtensions.cs
+++ b/Packages/Operations/BetweenExclusive/src/Extensions/IFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterableBetweenExclusiveExtensions
 {

--- a/Packages/Operations/BetweenExclusive/src/Extensions/IFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/BetweenExclusive/src/Extensions/IFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterable_TClass_BetweenExclusiveExtensions
 {

--- a/Packages/Operations/BetweenExclusive/src/Extensions/IQueryFilterableAddExtensions.cs
+++ b/Packages/Operations/BetweenExclusive/src/Extensions/IQueryFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterableBetweenExclusiveExtensions
 {

--- a/Packages/Operations/BetweenExclusive/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/BetweenExclusive/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterable_TClass_BetweenExclusiveExtensions
 {

--- a/Packages/Operations/BetweenExclusive/tests/AllTests.cs
+++ b/Packages/Operations/BetweenExclusive/tests/AllTests.cs
@@ -2,7 +2,7 @@ namespace ExpressionBuilder.Tests;
 
 using System.Collections.Generic;
 using ExpressionBuilder.Tests.Models;
-using TopMarksDevelopment.ExpressionBuilder.Operations;
+using TopMarksDevelopment.ExpressionBuilder;
 
 public class AllTests
 {

--- a/Packages/Operations/Contains/src/Extensions/IFilterAddExtensions.cs
+++ b/Packages/Operations/Contains/src/Extensions/IFilterAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterContainsExtensions
 {

--- a/Packages/Operations/Contains/src/Extensions/IFilter_TClass_AddExtensions.cs
+++ b/Packages/Operations/Contains/src/Extensions/IFilter_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilter_TClass_ContainsExtensions
 {

--- a/Packages/Operations/Contains/src/Extensions/IFilterableAddExtensions.cs
+++ b/Packages/Operations/Contains/src/Extensions/IFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterableContainsExtensions
 {

--- a/Packages/Operations/Contains/src/Extensions/IFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/Contains/src/Extensions/IFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterable_TClass_ContainsExtensions
 {

--- a/Packages/Operations/Contains/src/Extensions/IQueryFilterableAddExtensions.cs
+++ b/Packages/Operations/Contains/src/Extensions/IQueryFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterableContainsExtensions
 {

--- a/Packages/Operations/Contains/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/Contains/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterable_TClass_ContainsExtensions
 {

--- a/Packages/Operations/Contains/tests/AllTests.cs
+++ b/Packages/Operations/Contains/tests/AllTests.cs
@@ -2,7 +2,7 @@ namespace ExpressionBuilder.Tests;
 
 using System.Collections.Generic;
 using ExpressionBuilder.Tests.Models;
-using TopMarksDevelopment.ExpressionBuilder.Operations;
+using TopMarksDevelopment.ExpressionBuilder;
 
 public class AllTests
 {

--- a/Packages/Operations/DoesNotContain/src/Extensions/IFilterAddExtensions.cs
+++ b/Packages/Operations/DoesNotContain/src/Extensions/IFilterAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterDoesNotContainExtensions
 {

--- a/Packages/Operations/DoesNotContain/src/Extensions/IFilter_TClass_AddExtensions.cs
+++ b/Packages/Operations/DoesNotContain/src/Extensions/IFilter_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilter_TClass_DoesNotContainExtensions
 {

--- a/Packages/Operations/DoesNotContain/src/Extensions/IFilterableAddExtensions.cs
+++ b/Packages/Operations/DoesNotContain/src/Extensions/IFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterableDoesNotContainExtensions
 {

--- a/Packages/Operations/DoesNotContain/src/Extensions/IFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/DoesNotContain/src/Extensions/IFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterable_TClass_DoesNotContainExtensions
 {

--- a/Packages/Operations/DoesNotContain/src/Extensions/IQueryFilterableAddExtensions.cs
+++ b/Packages/Operations/DoesNotContain/src/Extensions/IQueryFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterableDoesNotContainExtensions
 {

--- a/Packages/Operations/DoesNotContain/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/DoesNotContain/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterable_TClass_DoesNotContainExtensions
 {

--- a/Packages/Operations/DoesNotContain/tests/AllTests.cs
+++ b/Packages/Operations/DoesNotContain/tests/AllTests.cs
@@ -2,7 +2,7 @@ namespace ExpressionBuilder.Tests;
 
 using System.Collections.Generic;
 using ExpressionBuilder.Tests.Models;
-using TopMarksDevelopment.ExpressionBuilder.Operations;
+using TopMarksDevelopment.ExpressionBuilder;
 
 public class AllTests
 {

--- a/Packages/Operations/DoesNotEndWith/src/Extensions/IFilterAddExtensions.cs
+++ b/Packages/Operations/DoesNotEndWith/src/Extensions/IFilterAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterDoesNotEndWithExtensions
 {

--- a/Packages/Operations/DoesNotEndWith/src/Extensions/IFilter_TClass_AddExtensions.cs
+++ b/Packages/Operations/DoesNotEndWith/src/Extensions/IFilter_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilter_TClass_DoesNotEndWithExtensions
 {

--- a/Packages/Operations/DoesNotEndWith/src/Extensions/IFilterableAddExtensions.cs
+++ b/Packages/Operations/DoesNotEndWith/src/Extensions/IFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterableDoesNotEndWithExtensions
 {

--- a/Packages/Operations/DoesNotEndWith/src/Extensions/IFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/DoesNotEndWith/src/Extensions/IFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterable_TClass_DoesNotEndWithExtensions
 {

--- a/Packages/Operations/DoesNotEndWith/src/Extensions/IQueryFilterableAddExtensions.cs
+++ b/Packages/Operations/DoesNotEndWith/src/Extensions/IQueryFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterableDoesNotEndWithExtensions
 {

--- a/Packages/Operations/DoesNotEndWith/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/DoesNotEndWith/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterable_TClass_DoesNotEndWithExtensions
 {

--- a/Packages/Operations/DoesNotEndWith/tests/AllTests.cs
+++ b/Packages/Operations/DoesNotEndWith/tests/AllTests.cs
@@ -2,7 +2,7 @@ namespace ExpressionBuilder.Tests;
 
 using System.Collections.Generic;
 using ExpressionBuilder.Tests.Models;
-using TopMarksDevelopment.ExpressionBuilder.Operations;
+using TopMarksDevelopment.ExpressionBuilder;
 
 public class AllTests
 {

--- a/Packages/Operations/DoesNotStartWith/src/Extensions/IFilterAddExtensions.cs
+++ b/Packages/Operations/DoesNotStartWith/src/Extensions/IFilterAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterDoesNotStartWithExtensions
 {

--- a/Packages/Operations/DoesNotStartWith/src/Extensions/IFilter_TClass_AddExtensions.cs
+++ b/Packages/Operations/DoesNotStartWith/src/Extensions/IFilter_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilter_TClass_DoesNotStartWithExtensions
 {

--- a/Packages/Operations/DoesNotStartWith/src/Extensions/IFilterableAddExtensions.cs
+++ b/Packages/Operations/DoesNotStartWith/src/Extensions/IFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterableDoesNotStartWithExtensions
 {

--- a/Packages/Operations/DoesNotStartWith/src/Extensions/IFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/DoesNotStartWith/src/Extensions/IFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterable_TClass_DoesNotStartWithExtensions
 {

--- a/Packages/Operations/DoesNotStartWith/src/Extensions/IQueryFilterableAddExtensions.cs
+++ b/Packages/Operations/DoesNotStartWith/src/Extensions/IQueryFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterableDoesNotStartWithExtensions
 {

--- a/Packages/Operations/DoesNotStartWith/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/DoesNotStartWith/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterable_TClass_DoesNotStartWithExtensions
 {

--- a/Packages/Operations/DoesNotStartWith/tests/AllTests.cs
+++ b/Packages/Operations/DoesNotStartWith/tests/AllTests.cs
@@ -2,7 +2,7 @@ namespace ExpressionBuilder.Tests;
 
 using System.Collections.Generic;
 using ExpressionBuilder.Tests.Models;
-using TopMarksDevelopment.ExpressionBuilder.Operations;
+using TopMarksDevelopment.ExpressionBuilder;
 
 public class AllTests
 {

--- a/Packages/Operations/EndsWith/src/Extensions/IFilterAddExtensions.cs
+++ b/Packages/Operations/EndsWith/src/Extensions/IFilterAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterEndsWithExtensions
 {

--- a/Packages/Operations/EndsWith/src/Extensions/IFilter_TClass_AddExtensions.cs
+++ b/Packages/Operations/EndsWith/src/Extensions/IFilter_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilter_TClass_EndsWithExtensions
 {

--- a/Packages/Operations/EndsWith/src/Extensions/IFilterableAddExtensions.cs
+++ b/Packages/Operations/EndsWith/src/Extensions/IFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterableEndsWithExtensions
 {

--- a/Packages/Operations/EndsWith/src/Extensions/IFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/EndsWith/src/Extensions/IFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterable_TClass_EndsWithExtensions
 {

--- a/Packages/Operations/EndsWith/src/Extensions/IQueryFilterableAddExtensions.cs
+++ b/Packages/Operations/EndsWith/src/Extensions/IQueryFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterableEndsWithExtensions
 {

--- a/Packages/Operations/EndsWith/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/EndsWith/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterable_TClass_EndsWithExtensions
 {

--- a/Packages/Operations/EndsWith/tests/AllTests.cs
+++ b/Packages/Operations/EndsWith/tests/AllTests.cs
@@ -2,7 +2,7 @@ namespace ExpressionBuilder.Tests;
 
 using System.Collections.Generic;
 using ExpressionBuilder.Tests.Models;
-using TopMarksDevelopment.ExpressionBuilder.Operations;
+using TopMarksDevelopment.ExpressionBuilder;
 
 public class AllTests
 {

--- a/Packages/Operations/Equal/src/Extensions/IFilterAddExtensions.cs
+++ b/Packages/Operations/Equal/src/Extensions/IFilterAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterEqualExtensions
 {

--- a/Packages/Operations/Equal/src/Extensions/IFilter_TClass_AddExtensions.cs
+++ b/Packages/Operations/Equal/src/Extensions/IFilter_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilter_TClass_EqualExtensions
 {

--- a/Packages/Operations/Equal/src/Extensions/IFilterableAddExtensions.cs
+++ b/Packages/Operations/Equal/src/Extensions/IFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterableEqualExtensions
 {

--- a/Packages/Operations/Equal/src/Extensions/IFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/Equal/src/Extensions/IFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterable_TClass_EqualExtensions
 {

--- a/Packages/Operations/Equal/src/Extensions/IQueryFilterableAddExtensions.cs
+++ b/Packages/Operations/Equal/src/Extensions/IQueryFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterableEqualExtensions
 {

--- a/Packages/Operations/Equal/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/Equal/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterable_TClass_EqualExtensions
 {

--- a/Packages/Operations/Equal/tests/AllTests.cs
+++ b/Packages/Operations/Equal/tests/AllTests.cs
@@ -3,7 +3,7 @@ namespace ExpressionBuilder.Tests;
 using System.Collections;
 using System.Collections.Generic;
 using ExpressionBuilder.Tests.Models;
-using TopMarksDevelopment.ExpressionBuilder.Operations;
+using TopMarksDevelopment.ExpressionBuilder;
 
 public class AllTests
 {

--- a/Packages/Operations/GreaterThan/src/Extensions/IFilterAddExtensions.cs
+++ b/Packages/Operations/GreaterThan/src/Extensions/IFilterAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterGreaterThanExtensions
 {

--- a/Packages/Operations/GreaterThan/src/Extensions/IFilter_TClass_AddExtensions.cs
+++ b/Packages/Operations/GreaterThan/src/Extensions/IFilter_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilter_TClass_GreaterThanExtensions
 {

--- a/Packages/Operations/GreaterThan/src/Extensions/IFilterableAddExtensions.cs
+++ b/Packages/Operations/GreaterThan/src/Extensions/IFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterableGreaterThanExtensions
 {

--- a/Packages/Operations/GreaterThan/src/Extensions/IFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/GreaterThan/src/Extensions/IFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterable_TClass_GreaterThanExtensions
 {

--- a/Packages/Operations/GreaterThan/src/Extensions/IQueryFilterableAddExtensions.cs
+++ b/Packages/Operations/GreaterThan/src/Extensions/IQueryFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterableGreaterThanExtensions
 {

--- a/Packages/Operations/GreaterThan/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/GreaterThan/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterable_TClass_GreaterThanExtensions
 {

--- a/Packages/Operations/GreaterThan/tests/AllTests.cs
+++ b/Packages/Operations/GreaterThan/tests/AllTests.cs
@@ -2,7 +2,7 @@ namespace ExpressionBuilder.Tests;
 
 using System.Collections.Generic;
 using ExpressionBuilder.Tests.Models;
-using TopMarksDevelopment.ExpressionBuilder.Operations;
+using TopMarksDevelopment.ExpressionBuilder;
 
 public class AllTests
 {

--- a/Packages/Operations/GreaterThanOrEqual/src/Extensions/IFilterAddExtensions.cs
+++ b/Packages/Operations/GreaterThanOrEqual/src/Extensions/IFilterAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterGreaterThanOrEqualExtensions
 {

--- a/Packages/Operations/GreaterThanOrEqual/src/Extensions/IFilter_TClass_AddExtensions.cs
+++ b/Packages/Operations/GreaterThanOrEqual/src/Extensions/IFilter_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilter_TClass_GreaterThanOrEqualExtensions
 {

--- a/Packages/Operations/GreaterThanOrEqual/src/Extensions/IFilterableAddExtensions.cs
+++ b/Packages/Operations/GreaterThanOrEqual/src/Extensions/IFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterableGreaterThanOrEqualExtensions
 {

--- a/Packages/Operations/GreaterThanOrEqual/src/Extensions/IFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/GreaterThanOrEqual/src/Extensions/IFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterable_TClass_GreaterThanOrEqualExtensions
 {

--- a/Packages/Operations/GreaterThanOrEqual/src/Extensions/IQueryFilterableAddExtensions.cs
+++ b/Packages/Operations/GreaterThanOrEqual/src/Extensions/IQueryFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterableGreaterThanOrEqualExtensions
 {

--- a/Packages/Operations/GreaterThanOrEqual/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/GreaterThanOrEqual/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterable_TClass_GreaterThanOrEqualExtensions
 {

--- a/Packages/Operations/GreaterThanOrEqual/tests/AllTests.cs
+++ b/Packages/Operations/GreaterThanOrEqual/tests/AllTests.cs
@@ -2,7 +2,7 @@ namespace ExpressionBuilder.Tests;
 
 using System.Collections.Generic;
 using ExpressionBuilder.Tests.Models;
-using TopMarksDevelopment.ExpressionBuilder.Operations;
+using TopMarksDevelopment.ExpressionBuilder;
 
 public class AllTests
 {

--- a/Packages/Operations/In/src/Extensions/IFilterAddExtensions.cs
+++ b/Packages/Operations/In/src/Extensions/IFilterAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterInExtensions
 {

--- a/Packages/Operations/In/src/Extensions/IFilter_TClass_AddExtensions.cs
+++ b/Packages/Operations/In/src/Extensions/IFilter_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilter_TClass_InExtensions
 {

--- a/Packages/Operations/In/src/Extensions/IFilterableAddExtensions.cs
+++ b/Packages/Operations/In/src/Extensions/IFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterableInExtensions
 {

--- a/Packages/Operations/In/src/Extensions/IFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/In/src/Extensions/IFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterable_TClass_InExtensions
 {

--- a/Packages/Operations/In/src/Extensions/IQueryFilterableAddExtensions.cs
+++ b/Packages/Operations/In/src/Extensions/IQueryFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterableInExtensions
 {

--- a/Packages/Operations/In/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/In/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterable_TClass_InExtensions
 {

--- a/Packages/Operations/In/tests/AllTests.cs
+++ b/Packages/Operations/In/tests/AllTests.cs
@@ -2,7 +2,7 @@ namespace ExpressionBuilder.Tests;
 
 using System.Collections.Generic;
 using ExpressionBuilder.Tests.Models;
-using TopMarksDevelopment.ExpressionBuilder.Operations;
+using TopMarksDevelopment.ExpressionBuilder;
 
 public class AllTests
 {

--- a/Packages/Operations/IsEmpty/src/Extensions/IFilterAddExtensions.cs
+++ b/Packages/Operations/IsEmpty/src/Extensions/IFilterAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterIsEmptyExtensions
 {

--- a/Packages/Operations/IsEmpty/src/Extensions/IFilter_TClass_AddExtensions.cs
+++ b/Packages/Operations/IsEmpty/src/Extensions/IFilter_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilter_TClass_IsEmptyExtensions
 {

--- a/Packages/Operations/IsEmpty/src/Extensions/IFilterableAddExtensions.cs
+++ b/Packages/Operations/IsEmpty/src/Extensions/IFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterableIsEmptyExtensions
 {

--- a/Packages/Operations/IsEmpty/src/Extensions/IFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/IsEmpty/src/Extensions/IFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterable_TClass_IsEmptyExtensions
 {

--- a/Packages/Operations/IsEmpty/src/Extensions/IQueryFilterableAddExtensions.cs
+++ b/Packages/Operations/IsEmpty/src/Extensions/IQueryFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterableIsEmptyExtensions
 {

--- a/Packages/Operations/IsEmpty/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/IsEmpty/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterable_TClass_IsEmptyExtensions
 {

--- a/Packages/Operations/IsEmpty/tests/AllTests.cs
+++ b/Packages/Operations/IsEmpty/tests/AllTests.cs
@@ -2,7 +2,7 @@ namespace ExpressionBuilder.Tests;
 
 using System.Collections.Generic;
 using ExpressionBuilder.Tests.Models;
-using TopMarksDevelopment.ExpressionBuilder.Operations;
+using TopMarksDevelopment.ExpressionBuilder;
 
 public class AllTests
 {

--- a/Packages/Operations/IsNotEmpty/src/Extensions/IFilterAddExtensions.cs
+++ b/Packages/Operations/IsNotEmpty/src/Extensions/IFilterAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterIsNotEmptyExtensions
 {

--- a/Packages/Operations/IsNotEmpty/src/Extensions/IFilter_TClass_AddExtensions.cs
+++ b/Packages/Operations/IsNotEmpty/src/Extensions/IFilter_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilter_TClass_IsNotEmptyExtensions
 {

--- a/Packages/Operations/IsNotEmpty/src/Extensions/IFilterableAddExtensions.cs
+++ b/Packages/Operations/IsNotEmpty/src/Extensions/IFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterableIsNotEmptyExtensions
 {

--- a/Packages/Operations/IsNotEmpty/src/Extensions/IFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/IsNotEmpty/src/Extensions/IFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterable_TClass_IsNotEmptyExtensions
 {

--- a/Packages/Operations/IsNotEmpty/src/Extensions/IQueryFilterableAddExtensions.cs
+++ b/Packages/Operations/IsNotEmpty/src/Extensions/IQueryFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterableIsNotEmptyExtensions
 {

--- a/Packages/Operations/IsNotEmpty/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/IsNotEmpty/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterable_TClass_IsNotEmptyExtensions
 {

--- a/Packages/Operations/IsNotEmpty/tests/AllTests.cs
+++ b/Packages/Operations/IsNotEmpty/tests/AllTests.cs
@@ -2,7 +2,7 @@ namespace ExpressionBuilder.Tests;
 
 using System.Collections.Generic;
 using ExpressionBuilder.Tests.Models;
-using TopMarksDevelopment.ExpressionBuilder.Operations;
+using TopMarksDevelopment.ExpressionBuilder;
 
 public class AllTests
 {

--- a/Packages/Operations/IsNotNull/src/Extensions/IFilterAddExtensions.cs
+++ b/Packages/Operations/IsNotNull/src/Extensions/IFilterAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterIsNotNullExtensions
 {

--- a/Packages/Operations/IsNotNull/src/Extensions/IFilter_TClass_AddExtensions.cs
+++ b/Packages/Operations/IsNotNull/src/Extensions/IFilter_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilter_TClass_IsNotNullExtensions
 {

--- a/Packages/Operations/IsNotNull/src/Extensions/IFilterableAddExtensions.cs
+++ b/Packages/Operations/IsNotNull/src/Extensions/IFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterableIsNotNullExtensions
 {

--- a/Packages/Operations/IsNotNull/src/Extensions/IFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/IsNotNull/src/Extensions/IFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterable_TClass_IsNotNullExtensions
 {

--- a/Packages/Operations/IsNotNull/src/Extensions/IQueryFilterableAddExtensions.cs
+++ b/Packages/Operations/IsNotNull/src/Extensions/IQueryFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterableIsNotNullExtensions
 {

--- a/Packages/Operations/IsNotNull/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/IsNotNull/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterable_TClass_IsNotNullExtensions
 {

--- a/Packages/Operations/IsNotNullOrWhiteSpace/src/Extensions/IFilterAddExtensions.cs
+++ b/Packages/Operations/IsNotNullOrWhiteSpace/src/Extensions/IFilterAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterIsNotNullOrWhiteSpaceExtensions
 {

--- a/Packages/Operations/IsNotNullOrWhiteSpace/src/Extensions/IFilter_TClass_AddExtensions.cs
+++ b/Packages/Operations/IsNotNullOrWhiteSpace/src/Extensions/IFilter_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilter_TClass_IsNotNullOrWhiteSpaceExtensions
 {

--- a/Packages/Operations/IsNotNullOrWhiteSpace/src/Extensions/IFilterableAddExtensions.cs
+++ b/Packages/Operations/IsNotNullOrWhiteSpace/src/Extensions/IFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterableIsNotNullOrWhiteSpaceExtensions
 {

--- a/Packages/Operations/IsNotNullOrWhiteSpace/src/Extensions/IFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/IsNotNullOrWhiteSpace/src/Extensions/IFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterable_TClass_IsNotNullOrWhiteSpaceExtensions
 {

--- a/Packages/Operations/IsNotNullOrWhiteSpace/src/Extensions/IQueryFilterableAddExtensions.cs
+++ b/Packages/Operations/IsNotNullOrWhiteSpace/src/Extensions/IQueryFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterableIsNotNullOrWhiteSpaceExtensions
 {

--- a/Packages/Operations/IsNotNullOrWhiteSpace/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/IsNotNullOrWhiteSpace/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterable_TClass_IsNotNullOrWhiteSpaceExtensions
 {

--- a/Packages/Operations/IsNull/src/Extensions/IFilterAddExtensions.cs
+++ b/Packages/Operations/IsNull/src/Extensions/IFilterAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterIsNullExtensions
 {

--- a/Packages/Operations/IsNull/src/Extensions/IFilter_TClass_AddExtensions.cs
+++ b/Packages/Operations/IsNull/src/Extensions/IFilter_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilter_TClass_IsNullExtensions
 {

--- a/Packages/Operations/IsNull/src/Extensions/IFilterableAddExtensions.cs
+++ b/Packages/Operations/IsNull/src/Extensions/IFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterableIsNullExtensions
 {

--- a/Packages/Operations/IsNull/src/Extensions/IFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/IsNull/src/Extensions/IFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterable_TClass_IsNullExtensions
 {

--- a/Packages/Operations/IsNull/src/Extensions/IQueryFilterableAddExtensions.cs
+++ b/Packages/Operations/IsNull/src/Extensions/IQueryFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterableIsNullExtensions
 {

--- a/Packages/Operations/IsNull/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/IsNull/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterable_TClass_IsNullExtensions
 {

--- a/Packages/Operations/IsNull/tests/AllTests.cs
+++ b/Packages/Operations/IsNull/tests/AllTests.cs
@@ -2,7 +2,7 @@ namespace ExpressionBuilder.Tests;
 
 using System.Collections.Generic;
 using ExpressionBuilder.Tests.Models;
-using TopMarksDevelopment.ExpressionBuilder.Operations;
+using TopMarksDevelopment.ExpressionBuilder;
 
 public class AllTests
 {

--- a/Packages/Operations/IsNullOrWhiteSpace/src/Extensions/IFilterAddExtensions.cs
+++ b/Packages/Operations/IsNullOrWhiteSpace/src/Extensions/IFilterAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterIsNullOrWhiteSpaceExtensions
 {

--- a/Packages/Operations/IsNullOrWhiteSpace/src/Extensions/IFilter_TClass_AddExtensions.cs
+++ b/Packages/Operations/IsNullOrWhiteSpace/src/Extensions/IFilter_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilter_TClass_IsNullOrWhiteSpaceExtensions
 {

--- a/Packages/Operations/IsNullOrWhiteSpace/src/Extensions/IFilterableAddExtensions.cs
+++ b/Packages/Operations/IsNullOrWhiteSpace/src/Extensions/IFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterableIsNullOrWhiteSpaceExtensions
 {

--- a/Packages/Operations/IsNullOrWhiteSpace/src/Extensions/IFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/IsNullOrWhiteSpace/src/Extensions/IFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterable_TClass_IsNullOrWhiteSpaceExtensions
 {

--- a/Packages/Operations/IsNullOrWhiteSpace/src/Extensions/IQueryFilterableAddExtensions.cs
+++ b/Packages/Operations/IsNullOrWhiteSpace/src/Extensions/IQueryFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterableIsNullOrWhiteSpaceExtensions
 {

--- a/Packages/Operations/IsNullOrWhiteSpace/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/IsNullOrWhiteSpace/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterable_TClass_IsNullOrWhiteSpaceExtensions
 {

--- a/Packages/Operations/LessThan/src/Extensions/IFilterAddExtensions.cs
+++ b/Packages/Operations/LessThan/src/Extensions/IFilterAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterLessThanExtensions
 {

--- a/Packages/Operations/LessThan/src/Extensions/IFilter_TClass_AddExtensions.cs
+++ b/Packages/Operations/LessThan/src/Extensions/IFilter_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilter_TClass_LessThanExtensions
 {

--- a/Packages/Operations/LessThan/src/Extensions/IFilterableAddExtensions.cs
+++ b/Packages/Operations/LessThan/src/Extensions/IFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterableLessThanExtensions
 {

--- a/Packages/Operations/LessThan/src/Extensions/IFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/LessThan/src/Extensions/IFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterable_TClass_LessThanExtensions
 {

--- a/Packages/Operations/LessThan/src/Extensions/IQueryFilterableAddExtensions.cs
+++ b/Packages/Operations/LessThan/src/Extensions/IQueryFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterableLessThanExtensions
 {

--- a/Packages/Operations/LessThan/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/LessThan/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterable_TClass_LessThanExtensions
 {

--- a/Packages/Operations/LessThanOrEqual/src/Extensions/IFilterAddExtensions.cs
+++ b/Packages/Operations/LessThanOrEqual/src/Extensions/IFilterAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterLessThanOrEqualExtensions
 {

--- a/Packages/Operations/LessThanOrEqual/src/Extensions/IFilter_TClass_AddExtensions.cs
+++ b/Packages/Operations/LessThanOrEqual/src/Extensions/IFilter_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilter_TClass_LessThanOrEqualExtensions
 {

--- a/Packages/Operations/LessThanOrEqual/src/Extensions/IFilterableAddExtensions.cs
+++ b/Packages/Operations/LessThanOrEqual/src/Extensions/IFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterableLessThanOrEqualExtensions
 {

--- a/Packages/Operations/LessThanOrEqual/src/Extensions/IFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/LessThanOrEqual/src/Extensions/IFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterable_TClass_LessThanOrEqualExtensions
 {

--- a/Packages/Operations/LessThanOrEqual/src/Extensions/IQueryFilterableAddExtensions.cs
+++ b/Packages/Operations/LessThanOrEqual/src/Extensions/IQueryFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterableLessThanOrEqualExtensions
 {

--- a/Packages/Operations/LessThanOrEqual/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/LessThanOrEqual/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterable_TClass_LessThanOrEqualExtensions
 {

--- a/Packages/Operations/NotBetween/src/Extensions/IFilterAddExtensions.cs
+++ b/Packages/Operations/NotBetween/src/Extensions/IFilterAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterNotBetweenExtensions
 {

--- a/Packages/Operations/NotBetween/src/Extensions/IFilter_TClass_AddExtensions.cs
+++ b/Packages/Operations/NotBetween/src/Extensions/IFilter_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilter_TClass_NotBetweenExtensions
 {

--- a/Packages/Operations/NotBetween/src/Extensions/IFilterableAddExtensions.cs
+++ b/Packages/Operations/NotBetween/src/Extensions/IFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterableNotBetweenExtensions
 {

--- a/Packages/Operations/NotBetween/src/Extensions/IFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/NotBetween/src/Extensions/IFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterable_TClass_NotBetweenExtensions
 {

--- a/Packages/Operations/NotBetween/src/Extensions/IQueryFilterableAddExtensions.cs
+++ b/Packages/Operations/NotBetween/src/Extensions/IQueryFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterableNotBetweenExtensions
 {

--- a/Packages/Operations/NotBetween/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/NotBetween/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterable_TClass_NotBetweenExtensions
 {

--- a/Packages/Operations/NotBetween/tests/AllTests.cs
+++ b/Packages/Operations/NotBetween/tests/AllTests.cs
@@ -2,7 +2,7 @@ namespace ExpressionBuilder.Tests;
 
 using System.Collections.Generic;
 using ExpressionBuilder.Tests.Models;
-using TopMarksDevelopment.ExpressionBuilder.Operations;
+using TopMarksDevelopment.ExpressionBuilder;
 
 public class AllTests
 {

--- a/Packages/Operations/NotBetweenExclusive/src/Extensions/IFilterAddExtensions.cs
+++ b/Packages/Operations/NotBetweenExclusive/src/Extensions/IFilterAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterNotBetweenExclusiveExtensions
 {

--- a/Packages/Operations/NotBetweenExclusive/src/Extensions/IFilter_TClass_AddExtensions.cs
+++ b/Packages/Operations/NotBetweenExclusive/src/Extensions/IFilter_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilter_TClass_NotBetweenExclusiveExtensions
 {

--- a/Packages/Operations/NotBetweenExclusive/src/Extensions/IFilterableAddExtensions.cs
+++ b/Packages/Operations/NotBetweenExclusive/src/Extensions/IFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterableNotBetweenExclusiveExtensions
 {

--- a/Packages/Operations/NotBetweenExclusive/src/Extensions/IFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/NotBetweenExclusive/src/Extensions/IFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterable_TClass_NotBetweenExclusiveExtensions
 {

--- a/Packages/Operations/NotBetweenExclusive/src/Extensions/IQueryFilterableAddExtensions.cs
+++ b/Packages/Operations/NotBetweenExclusive/src/Extensions/IQueryFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterableNotBetweenExclusiveExtensions
 {

--- a/Packages/Operations/NotBetweenExclusive/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/NotBetweenExclusive/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterable_TClass_NotBetweenExclusiveExtensions
 {

--- a/Packages/Operations/NotBetweenExclusive/tests/AllTests.cs
+++ b/Packages/Operations/NotBetweenExclusive/tests/AllTests.cs
@@ -2,7 +2,7 @@ namespace ExpressionBuilder.Tests;
 
 using System.Collections.Generic;
 using ExpressionBuilder.Tests.Models;
-using TopMarksDevelopment.ExpressionBuilder.Operations;
+using TopMarksDevelopment.ExpressionBuilder;
 
 public class AllTests
 {

--- a/Packages/Operations/NotEqual/src/Extensions/IFilterAddExtensions.cs
+++ b/Packages/Operations/NotEqual/src/Extensions/IFilterAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterNotEqualExtensions
 {

--- a/Packages/Operations/NotEqual/src/Extensions/IFilter_TClass_AddExtensions.cs
+++ b/Packages/Operations/NotEqual/src/Extensions/IFilter_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilter_TClass_NotEqualExtensions
 {

--- a/Packages/Operations/NotEqual/src/Extensions/IFilterableAddExtensions.cs
+++ b/Packages/Operations/NotEqual/src/Extensions/IFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterableNotEqualExtensions
 {

--- a/Packages/Operations/NotEqual/src/Extensions/IFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/NotEqual/src/Extensions/IFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterable_TClass_NotEqualExtensions
 {

--- a/Packages/Operations/NotEqual/src/Extensions/IQueryFilterableAddExtensions.cs
+++ b/Packages/Operations/NotEqual/src/Extensions/IQueryFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterableNotEqualExtensions
 {

--- a/Packages/Operations/NotEqual/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/NotEqual/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterable_TClass_NotEqualExtensions
 {

--- a/Packages/Operations/NotIn/src/Extensions/IFilterAddExtensions.cs
+++ b/Packages/Operations/NotIn/src/Extensions/IFilterAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterNotInExtensions
 {

--- a/Packages/Operations/NotIn/src/Extensions/IFilter_TClass_AddExtensions.cs
+++ b/Packages/Operations/NotIn/src/Extensions/IFilter_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilter_TClass_NotInExtensions
 {

--- a/Packages/Operations/NotIn/src/Extensions/IFilterableAddExtensions.cs
+++ b/Packages/Operations/NotIn/src/Extensions/IFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterableNotInExtensions
 {

--- a/Packages/Operations/NotIn/src/Extensions/IFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/NotIn/src/Extensions/IFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterable_TClass_NotInExtensions
 {

--- a/Packages/Operations/NotIn/src/Extensions/IQueryFilterableAddExtensions.cs
+++ b/Packages/Operations/NotIn/src/Extensions/IQueryFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterableNotInExtensions
 {

--- a/Packages/Operations/NotIn/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/NotIn/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterable_TClass_NotInExtensions
 {

--- a/Packages/Operations/NotIn/tests/AllTests.cs
+++ b/Packages/Operations/NotIn/tests/AllTests.cs
@@ -2,7 +2,7 @@ namespace ExpressionBuilder.Tests;
 
 using System.Collections.Generic;
 using ExpressionBuilder.Tests.Models;
-using TopMarksDevelopment.ExpressionBuilder.Operations;
+using TopMarksDevelopment.ExpressionBuilder;
 
 public class AllTests
 {

--- a/Packages/Operations/SmartSearch/src/Extensions/IFilterAddExtensions.cs
+++ b/Packages/Operations/SmartSearch/src/Extensions/IFilterAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterSmartSearchExtensions
 {

--- a/Packages/Operations/SmartSearch/src/Extensions/IFilter_TClass_AddExtensions.cs
+++ b/Packages/Operations/SmartSearch/src/Extensions/IFilter_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilter_TClass_SmartSearchExtensions
 {

--- a/Packages/Operations/SmartSearch/src/Extensions/IFilterableAddExtensions.cs
+++ b/Packages/Operations/SmartSearch/src/Extensions/IFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterableSmartSearchExtensions
 {

--- a/Packages/Operations/SmartSearch/src/Extensions/IFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/SmartSearch/src/Extensions/IFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterable_TClass_SmartSearchExtensions
 {

--- a/Packages/Operations/SmartSearch/src/Extensions/IQueryFilterableAddExtensions.cs
+++ b/Packages/Operations/SmartSearch/src/Extensions/IQueryFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterableSmartSearchExtensions
 {

--- a/Packages/Operations/SmartSearch/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/SmartSearch/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterable_TClass_SmartSearchExtensions
 {

--- a/Packages/Operations/SmartSearch/tests/AllTests.cs
+++ b/Packages/Operations/SmartSearch/tests/AllTests.cs
@@ -2,7 +2,7 @@ namespace ExpressionBuilder.Tests;
 
 using System.Collections.Generic;
 using ExpressionBuilder.Tests.Models;
-using TopMarksDevelopment.ExpressionBuilder.Operations;
+using TopMarksDevelopment.ExpressionBuilder;
 
 public class AllTests
 {

--- a/Packages/Operations/StartsWith/src/Extensions/IFilterAddExtensions.cs
+++ b/Packages/Operations/StartsWith/src/Extensions/IFilterAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterStartsWithExtensions
 {

--- a/Packages/Operations/StartsWith/src/Extensions/IFilter_TClass_AddExtensions.cs
+++ b/Packages/Operations/StartsWith/src/Extensions/IFilter_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilter_TClass_StartsWithExtensions
 {

--- a/Packages/Operations/StartsWith/src/Extensions/IFilterableAddExtensions.cs
+++ b/Packages/Operations/StartsWith/src/Extensions/IFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterableStartsWithExtensions
 {

--- a/Packages/Operations/StartsWith/src/Extensions/IFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/StartsWith/src/Extensions/IFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IFilterable_TClass_StartsWithExtensions
 {

--- a/Packages/Operations/StartsWith/src/Extensions/IQueryFilterableAddExtensions.cs
+++ b/Packages/Operations/StartsWith/src/Extensions/IQueryFilterableAddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterableStartsWithExtensions
 {

--- a/Packages/Operations/StartsWith/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
+++ b/Packages/Operations/StartsWith/src/Extensions/IQueryFilterable_TClass_AddExtensions.cs
@@ -1,8 +1,9 @@
-namespace TopMarksDevelopment.ExpressionBuilder.Operations;
+namespace TopMarksDevelopment.ExpressionBuilder;
 
 using System;
 using System.Linq.Expressions;
 using TopMarksDevelopment.ExpressionBuilder.Api;
+using TopMarksDevelopment.ExpressionBuilder.Operations;
 
 public static partial class IQueryFilterable_TClass_StartsWithExtensions
 {

--- a/Packages/Operations/StartsWith/tests/AllTests.cs
+++ b/Packages/Operations/StartsWith/tests/AllTests.cs
@@ -2,7 +2,7 @@ namespace ExpressionBuilder.Tests;
 
 using System.Collections.Generic;
 using ExpressionBuilder.Tests.Models;
-using TopMarksDevelopment.ExpressionBuilder.Operations;
+using TopMarksDevelopment.ExpressionBuilder;
 
 public class AllTests
 {


### PR DESCRIPTION
-   Moved all extension methods from the `TopMarksDevelopment.ExpressionBuilder.Api` namespace to `TopMarksDevelopment.ExpressionBuilder`, for easier access _(not technically "breaking" as the main package is always required to operate)_