### PR TITLE
Fix copyright year and NuGet links

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -25,9 +25,19 @@ All notable changes to this project will be documented in this file.
 
 > ❗ Whilst in the beta phase, breaking changes will happen between "minor" releases. Because of this, patches and new features will happen at between "patch" releases.
 
-## [0.2.1-beta] - UNPUBLISHED
+## <!-- [0.2.1-beta] - -->UNPUBLISHED
 
-<small>[Compare to previous release][comp:0.2.1-beta]</small>
+<!-- <small>[Compare to previous release][comp:0.2.1-beta]</small> -->
+
+### Package: TopMarksDevelopment.ExpressionBuilder(* All)
+
+#### Fixed
+
+-   Fixed the paths for the icons and the links to GitHub source code
+
+#### Changed
+
+-   Updated the copyright year for NuGet packages and `License.md`
 
 ### Package: TopMarksDevelopment.ExpressionBuilder.Operations.* (All Operations)
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Top Marks Development Limited
+Copyright (c) 2024 Top Marks Development Limited
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/Packages/Api/src/Api.Src.csproj
+++ b/Packages/Api/src/Api.Src.csproj
@@ -11,13 +11,13 @@
     <title>Expression Builder (API)</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>
-    <licenseUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/LICENSE</licenseUrl>
-    <projectUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/ExpressionBuilder/Assets/icon.png</iconUrl>
+    <licenseUrl>https://github.com/TopMarksDevelopment/Expression-Builder/blob/main/LICENSE.md</licenseUrl>
+    <projectUrl>https://github.com/TopMarksDevelopment/Expression-Builder/</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/Expression-Builder/main/assets/icon.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <Description>Looking to exapnd the functionality of the "ExpressionBuilder" package? This is the starting point for you. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</Description>
     <summary>Looking to exapnd the functionality of the "ExpressionBuilder" package? This is the starting point for you. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</summary>
-    <copyright>Top Marks Development Limited © 2023</copyright>
+    <copyright>Top Marks Development Limited © 2024</copyright>
     <language>en-GB</language>
     <PackageTags>Expression Builder Func LINQ Lambda Database IQuery LINQ SQL LINQ2SQL Queryable</PackageTags>
     <releaseNotes>

--- a/Packages/Core/src/Core.Src.csproj
+++ b/Packages/Core/src/Core.Src.csproj
@@ -11,13 +11,13 @@
     <title>Expression Builder (Core Functionality)</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>
-    <licenseUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/LICENSE</licenseUrl>
-    <projectUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/ExpressionBuilder/Assets/icon.png</iconUrl>
+    <licenseUrl>https://github.com/TopMarksDevelopment/Expression-Builder/blob/main/LICENSE.md</licenseUrl>
+    <projectUrl>https://github.com/TopMarksDevelopment/Expression-Builder/</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/Expression-Builder/main/assets/icon.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <Description>Core package, with no operations included - pick and choose what you use. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</Description>
     <summary>Core package, with no operations included - pick and choose what you use. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</summary>
-    <copyright>Top Marks Development Limited © 2023</copyright>
+    <copyright>Top Marks Development Limited © 2024</copyright>
     <language>en-GB</language>
     <PackageTags>Expression Builder Func LINQ Lambda Database IQuery LINQ SQL LINQ2SQL Queryable</PackageTags>
     <releaseNotes>

--- a/Packages/Main/src/Main.Src.csproj
+++ b/Packages/Main/src/Main.Src.csproj
@@ -11,13 +11,13 @@
     <title>Expression Builder</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>
-    <licenseUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/LICENSE</licenseUrl>
-    <projectUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/ExpressionBuilder/Assets/icon.png</iconUrl>
+    <licenseUrl>https://github.com/TopMarksDevelopment/Expression-Builder/blob/main/LICENSE.md</licenseUrl>
+    <projectUrl>https://github.com/TopMarksDevelopment/Expression-Builder/</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/Expression-Builder/main/assets/icon.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <Description>Easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</Description>
     <summary>Easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</summary>
-    <copyright>Top Marks Development Limited © 2023</copyright>
+    <copyright>Top Marks Development Limited © 2024</copyright>
     <language>en-GB</language>
     <PackageTags>Expression Builder Func LINQ Lambda Database IQuery LINQ SQL LINQ2SQL Queryable</PackageTags>
     <releaseNotes>

--- a/Packages/Operations/Between/src/Operations.Between.Src.csproj
+++ b/Packages/Operations/Between/src/Operations.Between.Src.csproj
@@ -11,13 +11,13 @@
     <title>Expression Builder - Operation: Between</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>
-    <licenseUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/LICENSE</licenseUrl>
-    <projectUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/ExpressionBuilder/Assets/icon.png</iconUrl>
+    <licenseUrl>https://github.com/TopMarksDevelopment/Expression-Builder/blob/main/LICENSE.md</licenseUrl>
+    <projectUrl>https://github.com/TopMarksDevelopment/Expression-Builder/</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/Expression-Builder/main/assets/icon.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <Description>The "Between" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</Description>
     <summary>The "Between" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</summary>
-    <copyright>Top Marks Development Limited © 2023</copyright>
+    <copyright>Top Marks Development Limited © 2024</copyright>
     <language>en-GB</language>
     <PackageTags>Expression Builder Func LINQ Lambda Database IQuery LINQ SQL LINQ2SQL Queryable</PackageTags>
     <releaseNotes>

--- a/Packages/Operations/BetweenExclusive/src/Operations.BetweenExclusive.Src.csproj
+++ b/Packages/Operations/BetweenExclusive/src/Operations.BetweenExclusive.Src.csproj
@@ -11,13 +11,13 @@
     <title>Expression Builder - Operation: BetweenExclusive</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>
-    <licenseUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/LICENSE</licenseUrl>
-    <projectUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/ExpressionBuilder/Assets/icon.png</iconUrl>
+    <licenseUrl>https://github.com/TopMarksDevelopment/Expression-Builder/blob/main/LICENSE.md</licenseUrl>
+    <projectUrl>https://github.com/TopMarksDevelopment/Expression-Builder/</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/Expression-Builder/main/assets/icon.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <Description>The "BetweenExclusive" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</Description>
     <summary>The "BetweenExclusive" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</summary>
-    <copyright>Top Marks Development Limited © 2023</copyright>
+    <copyright>Top Marks Development Limited © 2024</copyright>
     <language>en-GB</language>
     <PackageTags>Expression Builder Func LINQ Lambda Database IQuery LINQ SQL LINQ2SQL Queryable</PackageTags>
     <releaseNotes>

--- a/Packages/Operations/Contains/src/Operations.Contains.Src.csproj
+++ b/Packages/Operations/Contains/src/Operations.Contains.Src.csproj
@@ -11,13 +11,13 @@
     <title>Expression Builder - Operation: Contains</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>
-    <licenseUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/LICENSE</licenseUrl>
-    <projectUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/ExpressionBuilder/Assets/icon.png</iconUrl>
+    <licenseUrl>https://github.com/TopMarksDevelopment/Expression-Builder/blob/main/LICENSE.md</licenseUrl>
+    <projectUrl>https://github.com/TopMarksDevelopment/Expression-Builder/</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/Expression-Builder/main/assets/icon.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <Description>The "Contains" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</Description>
     <summary>The "Contains" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</summary>
-    <copyright>Top Marks Development Limited © 2023</copyright>
+    <copyright>Top Marks Development Limited © 2024</copyright>
     <language>en-GB</language>
     <PackageTags>Expression Builder Func LINQ Lambda Database IQuery LINQ SQL LINQ2SQL Queryable</PackageTags>
     <releaseNotes>

--- a/Packages/Operations/DoesNotContain/src/Operations.DoesNotContain.Src.csproj
+++ b/Packages/Operations/DoesNotContain/src/Operations.DoesNotContain.Src.csproj
@@ -11,13 +11,13 @@
     <title>Expression Builder - Operation: DoesNotContain</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>
-    <licenseUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/LICENSE</licenseUrl>
-    <projectUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/ExpressionBuilder/Assets/icon.png</iconUrl>
+    <licenseUrl>https://github.com/TopMarksDevelopment/Expression-Builder/blob/main/LICENSE.md</licenseUrl>
+    <projectUrl>https://github.com/TopMarksDevelopment/Expression-Builder/</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/Expression-Builder/main/assets/icon.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <Description>The "DoesNotContain" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</Description>
     <summary>The "DoesNotContain" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</summary>
-    <copyright>Top Marks Development Limited © 2023</copyright>
+    <copyright>Top Marks Development Limited © 2024</copyright>
     <language>en-GB</language>
     <PackageTags>Expression Builder Func LINQ Lambda Database IQuery LINQ SQL LINQ2SQL Queryable</PackageTags>
     <releaseNotes>

--- a/Packages/Operations/DoesNotEndWith/src/Operations.DoesNotEndWith.Src.csproj
+++ b/Packages/Operations/DoesNotEndWith/src/Operations.DoesNotEndWith.Src.csproj
@@ -11,13 +11,13 @@
     <title>Expression Builder - Operation: DoesNotEndWith</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>
-    <licenseUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/LICENSE</licenseUrl>
-    <projectUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/ExpressionBuilder/Assets/icon.png</iconUrl>
+    <licenseUrl>https://github.com/TopMarksDevelopment/Expression-Builder/blob/main/LICENSE.md</licenseUrl>
+    <projectUrl>https://github.com/TopMarksDevelopment/Expression-Builder/</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/Expression-Builder/main/assets/icon.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <Description>The "DoesNotEndWith" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</Description>
     <summary>The "DoesNotEndWith" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</summary>
-    <copyright>Top Marks Development Limited © 2023</copyright>
+    <copyright>Top Marks Development Limited © 2024</copyright>
     <language>en-GB</language>
     <PackageTags>Expression Builder Func LINQ Lambda Database IQuery LINQ SQL LINQ2SQL Queryable</PackageTags>
     <releaseNotes>

--- a/Packages/Operations/DoesNotStartWith/src/Operations.DoesNotStartWith.Src.csproj
+++ b/Packages/Operations/DoesNotStartWith/src/Operations.DoesNotStartWith.Src.csproj
@@ -11,13 +11,13 @@
     <title>Expression Builder - Operation: DoesNotStartWith</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>
-    <licenseUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/LICENSE</licenseUrl>
-    <projectUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/ExpressionBuilder/Assets/icon.png</iconUrl>
+    <licenseUrl>https://github.com/TopMarksDevelopment/Expression-Builder/blob/main/LICENSE.md</licenseUrl>
+    <projectUrl>https://github.com/TopMarksDevelopment/Expression-Builder/</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/Expression-Builder/main/assets/icon.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <Description>The "DoesNotStartWith" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</Description>
     <summary>The "DoesNotStartWith" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</summary>
-    <copyright>Top Marks Development Limited © 2023</copyright>
+    <copyright>Top Marks Development Limited © 2024</copyright>
     <language>en-GB</language>
     <PackageTags>Expression Builder Func LINQ Lambda Database IQuery LINQ SQL LINQ2SQL Queryable</PackageTags>
     <releaseNotes>

--- a/Packages/Operations/EndsWith/src/Operations.EndsWith.Src.csproj
+++ b/Packages/Operations/EndsWith/src/Operations.EndsWith.Src.csproj
@@ -11,13 +11,13 @@
     <title>Expression Builder - Operation: EndsWith</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>
-    <licenseUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/LICENSE</licenseUrl>
-    <projectUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/ExpressionBuilder/Assets/icon.png</iconUrl>
+    <licenseUrl>https://github.com/TopMarksDevelopment/Expression-Builder/blob/main/LICENSE.md</licenseUrl>
+    <projectUrl>https://github.com/TopMarksDevelopment/Expression-Builder/</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/Expression-Builder/main/assets/icon.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <Description>The "EndsWith" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</Description>
     <summary>The "EndsWith" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</summary>
-    <copyright>Top Marks Development Limited © 2023</copyright>
+    <copyright>Top Marks Development Limited © 2024</copyright>
     <language>en-GB</language>
     <PackageTags>Expression Builder Func LINQ Lambda Database IQuery LINQ SQL LINQ2SQL Queryable</PackageTags>
     <releaseNotes>

--- a/Packages/Operations/Equal/src/Operations.Equal.Src.csproj
+++ b/Packages/Operations/Equal/src/Operations.Equal.Src.csproj
@@ -11,13 +11,13 @@
     <title>Expression Builder - Operation: Equal</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>
-    <licenseUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/LICENSE</licenseUrl>
-    <projectUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/ExpressionBuilder/Assets/icon.png</iconUrl>
+    <licenseUrl>https://github.com/TopMarksDevelopment/Expression-Builder/blob/main/LICENSE.md</licenseUrl>
+    <projectUrl>https://github.com/TopMarksDevelopment/Expression-Builder/</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/Expression-Builder/main/assets/icon.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <Description>The "Equal" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</Description>
     <summary>The "Equal" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</summary>
-    <copyright>Top Marks Development Limited © 2023</copyright>
+    <copyright>Top Marks Development Limited © 2024</copyright>
     <language>en-GB</language>
     <PackageTags>Expression Builder Func LINQ Lambda Database IQuery LINQ SQL LINQ2SQL Queryable</PackageTags>
     <releaseNotes>

--- a/Packages/Operations/GreaterThan/src/Operations.GreaterThan.Src.csproj
+++ b/Packages/Operations/GreaterThan/src/Operations.GreaterThan.Src.csproj
@@ -11,13 +11,13 @@
     <title>Expression Builder - Operation: GreaterThan</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>
-    <licenseUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/LICENSE</licenseUrl>
-    <projectUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/ExpressionBuilder/Assets/icon.png</iconUrl>
+    <licenseUrl>https://github.com/TopMarksDevelopment/Expression-Builder/blob/main/LICENSE.md</licenseUrl>
+    <projectUrl>https://github.com/TopMarksDevelopment/Expression-Builder/</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/Expression-Builder/main/assets/icon.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <Description>The "GreaterThan" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</Description>
     <summary>The "GreaterThan" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</summary>
-    <copyright>Top Marks Development Limited © 2023</copyright>
+    <copyright>Top Marks Development Limited © 2024</copyright>
     <language>en-GB</language>
     <PackageTags>Expression Builder Func LINQ Lambda Database IQuery LINQ SQL LINQ2SQL Queryable</PackageTags>
     <releaseNotes>

--- a/Packages/Operations/GreaterThanOrEqual/src/Operations.GreaterThanOrEqual.Src.csproj
+++ b/Packages/Operations/GreaterThanOrEqual/src/Operations.GreaterThanOrEqual.Src.csproj
@@ -11,13 +11,13 @@
     <title>Expression Builder - Operation: GreaterThanOrEqual</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>
-    <licenseUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/LICENSE</licenseUrl>
-    <projectUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/ExpressionBuilder/Assets/icon.png</iconUrl>
+    <licenseUrl>https://github.com/TopMarksDevelopment/Expression-Builder/blob/main/LICENSE.md</licenseUrl>
+    <projectUrl>https://github.com/TopMarksDevelopment/Expression-Builder/</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/Expression-Builder/main/assets/icon.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <Description>The "GreaterThanOrEqual" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</Description>
     <summary>The "GreaterThanOrEqual" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</summary>
-    <copyright>Top Marks Development Limited © 2023</copyright>
+    <copyright>Top Marks Development Limited © 2024</copyright>
     <language>en-GB</language>
     <PackageTags>Expression Builder Func LINQ Lambda Database IQuery LINQ SQL LINQ2SQL Queryable</PackageTags>
     <releaseNotes>

--- a/Packages/Operations/In/src/Operations.In.Src.csproj
+++ b/Packages/Operations/In/src/Operations.In.Src.csproj
@@ -11,13 +11,13 @@
     <title>Expression Builder - Operation: In</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>
-    <licenseUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/LICENSE</licenseUrl>
-    <projectUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/ExpressionBuilder/Assets/icon.png</iconUrl>
+    <licenseUrl>https://github.com/TopMarksDevelopment/Expression-Builder/blob/main/LICENSE.md</licenseUrl>
+    <projectUrl>https://github.com/TopMarksDevelopment/Expression-Builder/</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/Expression-Builder/main/assets/icon.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <Description>The "In" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</Description>
     <summary>The "In" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</summary>
-    <copyright>Top Marks Development Limited © 2023</copyright>
+    <copyright>Top Marks Development Limited © 2024</copyright>
     <language>en-GB</language>
     <PackageTags>Expression Builder Func LINQ Lambda Database IQuery LINQ SQL LINQ2SQL Queryable</PackageTags>
     <releaseNotes>

--- a/Packages/Operations/IsEmpty/src/Operations.IsEmpty.Src.csproj
+++ b/Packages/Operations/IsEmpty/src/Operations.IsEmpty.Src.csproj
@@ -11,13 +11,13 @@
     <title>Expression Builder - Operation: IsEmpty</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>
-    <licenseUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/LICENSE</licenseUrl>
-    <projectUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/ExpressionBuilder/Assets/icon.png</iconUrl>
+    <licenseUrl>https://github.com/TopMarksDevelopment/Expression-Builder/blob/main/LICENSE.md</licenseUrl>
+    <projectUrl>https://github.com/TopMarksDevelopment/Expression-Builder/</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/Expression-Builder/main/assets/icon.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <Description>The "IsEmpty" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</Description>
     <summary>The "IsEmpty" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</summary>
-    <copyright>Top Marks Development Limited © 2023</copyright>
+    <copyright>Top Marks Development Limited © 2024</copyright>
     <language>en-GB</language>
     <PackageTags>Expression Builder Func LINQ Lambda Database IQuery LINQ SQL LINQ2SQL Queryable</PackageTags>
     <releaseNotes>

--- a/Packages/Operations/IsNotEmpty/src/Operations.IsNotEmpty.Src.csproj
+++ b/Packages/Operations/IsNotEmpty/src/Operations.IsNotEmpty.Src.csproj
@@ -11,13 +11,13 @@
     <title>Expression Builder - Operation: IsNotEmpty</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>
-    <licenseUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/LICENSE</licenseUrl>
-    <projectUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/ExpressionBuilder/Assets/icon.png</iconUrl>
+    <licenseUrl>https://github.com/TopMarksDevelopment/Expression-Builder/blob/main/LICENSE.md</licenseUrl>
+    <projectUrl>https://github.com/TopMarksDevelopment/Expression-Builder/</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/Expression-Builder/main/assets/icon.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <Description>The "IsNotEmpty" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</Description>
     <summary>The "IsNotEmpty" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</summary>
-    <copyright>Top Marks Development Limited © 2023</copyright>
+    <copyright>Top Marks Development Limited © 2024</copyright>
     <language>en-GB</language>
     <PackageTags>Expression Builder Func LINQ Lambda Database IQuery LINQ SQL LINQ2SQL Queryable</PackageTags>
     <releaseNotes>

--- a/Packages/Operations/IsNotNull/src/Operations.IsNotNull.Src.csproj
+++ b/Packages/Operations/IsNotNull/src/Operations.IsNotNull.Src.csproj
@@ -11,13 +11,13 @@
     <title>Expression Builder - Operation: IsNotNull</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>
-    <licenseUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/LICENSE</licenseUrl>
-    <projectUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/ExpressionBuilder/Assets/icon.png</iconUrl>
+    <licenseUrl>https://github.com/TopMarksDevelopment/Expression-Builder/blob/main/LICENSE.md</licenseUrl>
+    <projectUrl>https://github.com/TopMarksDevelopment/Expression-Builder/</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/Expression-Builder/main/assets/icon.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <Description>The "IsNotNull" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</Description>
     <summary>The "IsNotNull" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</summary>
-    <copyright>Top Marks Development Limited © 2023</copyright>
+    <copyright>Top Marks Development Limited © 2024</copyright>
     <language>en-GB</language>
     <PackageTags>Expression Builder Func LINQ Lambda Database IQuery LINQ SQL LINQ2SQL Queryable</PackageTags>
     <releaseNotes>

--- a/Packages/Operations/IsNotNullOrWhiteSpace/src/Operations.IsNotNullOrWhiteSpace.Src.csproj
+++ b/Packages/Operations/IsNotNullOrWhiteSpace/src/Operations.IsNotNullOrWhiteSpace.Src.csproj
@@ -11,13 +11,13 @@
     <title>Expression Builder - Operation: IsNotNullOrWhiteSpace</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>
-    <licenseUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/LICENSE</licenseUrl>
-    <projectUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/ExpressionBuilder/Assets/icon.png</iconUrl>
+    <licenseUrl>https://github.com/TopMarksDevelopment/Expression-Builder/blob/main/LICENSE.md</licenseUrl>
+    <projectUrl>https://github.com/TopMarksDevelopment/Expression-Builder/</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/Expression-Builder/main/assets/icon.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <Description>The "IsNotNullOrWhiteSpace" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</Description>
     <summary>The "IsNotNullOrWhiteSpace" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</summary>
-    <copyright>Top Marks Development Limited © 2023</copyright>
+    <copyright>Top Marks Development Limited © 2024</copyright>
     <language>en-GB</language>
     <PackageTags>Expression Builder Func LINQ Lambda Database IQuery LINQ SQL LINQ2SQL Queryable</PackageTags>
     <releaseNotes>

--- a/Packages/Operations/IsNull/src/Operations.IsNull.Src.csproj
+++ b/Packages/Operations/IsNull/src/Operations.IsNull.Src.csproj
@@ -11,13 +11,13 @@
     <title>Expression Builder - Operation: IsNull</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>
-    <licenseUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/LICENSE</licenseUrl>
-    <projectUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/ExpressionBuilder/Assets/icon.png</iconUrl>
+    <licenseUrl>https://github.com/TopMarksDevelopment/Expression-Builder/blob/main/LICENSE.md</licenseUrl>
+    <projectUrl>https://github.com/TopMarksDevelopment/Expression-Builder/</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/Expression-Builder/main/assets/icon.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <Description>The "IsNull" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</Description>
     <summary>The "IsNull" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</summary>
-    <copyright>Top Marks Development Limited © 2023</copyright>
+    <copyright>Top Marks Development Limited © 2024</copyright>
     <language>en-GB</language>
     <PackageTags>Expression Builder Func LINQ Lambda Database IQuery LINQ SQL LINQ2SQL Queryable</PackageTags>
     <releaseNotes>

--- a/Packages/Operations/IsNullOrWhiteSpace/src/Operations.IsNullOrWhiteSpace.Src.csproj
+++ b/Packages/Operations/IsNullOrWhiteSpace/src/Operations.IsNullOrWhiteSpace.Src.csproj
@@ -11,13 +11,13 @@
     <title>Expression Builder - Operation: IsNullOrWhiteSpace</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>
-    <licenseUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/LICENSE</licenseUrl>
-    <projectUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/ExpressionBuilder/Assets/icon.png</iconUrl>
+    <licenseUrl>https://github.com/TopMarksDevelopment/Expression-Builder/blob/main/LICENSE.md</licenseUrl>
+    <projectUrl>https://github.com/TopMarksDevelopment/Expression-Builder/</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/Expression-Builder/main/assets/icon.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <Description>The "IsNullOrWhiteSpace" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</Description>
     <summary>The "IsNullOrWhiteSpace" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</summary>
-    <copyright>Top Marks Development Limited © 2023</copyright>
+    <copyright>Top Marks Development Limited © 2024</copyright>
     <language>en-GB</language>
     <PackageTags>Expression Builder Func LINQ Lambda Database IQuery LINQ SQL LINQ2SQL Queryable</PackageTags>
     <releaseNotes>

--- a/Packages/Operations/LessThan/src/Operations.LessThan.Src.csproj
+++ b/Packages/Operations/LessThan/src/Operations.LessThan.Src.csproj
@@ -11,13 +11,13 @@
     <title>Expression Builder - Operation: LessThan</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>
-    <licenseUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/LICENSE</licenseUrl>
-    <projectUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/ExpressionBuilder/Assets/icon.png</iconUrl>
+    <licenseUrl>https://github.com/TopMarksDevelopment/Expression-Builder/blob/main/LICENSE.md</licenseUrl>
+    <projectUrl>https://github.com/TopMarksDevelopment/Expression-Builder/</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/Expression-Builder/main/assets/icon.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <Description>The "LessThan" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</Description>
     <summary>The "LessThan" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</summary>
-    <copyright>Top Marks Development Limited © 2023</copyright>
+    <copyright>Top Marks Development Limited © 2024</copyright>
     <language>en-GB</language>
     <PackageTags>Expression Builder Func LINQ Lambda Database IQuery LINQ SQL LINQ2SQL Queryable</PackageTags>
     <releaseNotes>

--- a/Packages/Operations/LessThanOrEqual/src/Operations.LessThanOrEqual.Src.csproj
+++ b/Packages/Operations/LessThanOrEqual/src/Operations.LessThanOrEqual.Src.csproj
@@ -11,13 +11,13 @@
     <title>Expression Builder - Operation: LessThanOrEqual</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>
-    <licenseUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/LICENSE</licenseUrl>
-    <projectUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/ExpressionBuilder/Assets/icon.png</iconUrl>
+    <licenseUrl>https://github.com/TopMarksDevelopment/Expression-Builder/blob/main/LICENSE.md</licenseUrl>
+    <projectUrl>https://github.com/TopMarksDevelopment/Expression-Builder/</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/Expression-Builder/main/assets/icon.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <Description>The "LessThanOrEqual" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</Description>
     <summary>The "LessThanOrEqual" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</summary>
-    <copyright>Top Marks Development Limited © 2023</copyright>
+    <copyright>Top Marks Development Limited © 2024</copyright>
     <language>en-GB</language>
     <PackageTags>Expression Builder Func LINQ Lambda Database IQuery LINQ SQL LINQ2SQL Queryable</PackageTags>
     <releaseNotes>

--- a/Packages/Operations/NotBetween/src/Operations.NotBetween.Src.csproj
+++ b/Packages/Operations/NotBetween/src/Operations.NotBetween.Src.csproj
@@ -11,13 +11,13 @@
     <title>Expression Builder - Operation: NotBetween</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>
-    <licenseUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/LICENSE</licenseUrl>
-    <projectUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/ExpressionBuilder/Assets/icon.png</iconUrl>
+    <licenseUrl>https://github.com/TopMarksDevelopment/Expression-Builder/blob/main/LICENSE.md</licenseUrl>
+    <projectUrl>https://github.com/TopMarksDevelopment/Expression-Builder/</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/Expression-Builder/main/assets/icon.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <Description>The "NotBetween" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</Description>
     <summary>The "NotBetween" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</summary>
-    <copyright>Top Marks Development Limited © 2023</copyright>
+    <copyright>Top Marks Development Limited © 2024</copyright>
     <language>en-GB</language>
     <PackageTags>Expression Builder Func LINQ Lambda Database IQuery LINQ SQL LINQ2SQL Queryable</PackageTags>
     <releaseNotes>

--- a/Packages/Operations/NotBetweenExclusive/src/Operations.NotBetweenExclusive.Src.csproj
+++ b/Packages/Operations/NotBetweenExclusive/src/Operations.NotBetweenExclusive.Src.csproj
@@ -11,13 +11,13 @@
     <title>Expression Builder - Operation: NotBetweenExclusive</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>
-    <licenseUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/LICENSE</licenseUrl>
-    <projectUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/ExpressionBuilder/Assets/icon.png</iconUrl>
+    <licenseUrl>https://github.com/TopMarksDevelopment/Expression-Builder/blob/main/LICENSE.md</licenseUrl>
+    <projectUrl>https://github.com/TopMarksDevelopment/Expression-Builder/</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/Expression-Builder/main/assets/icon.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <Description>The "NotBetweenExclusive" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</Description>
     <summary>The "NotBetweenExclusive" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</summary>
-    <copyright>Top Marks Development Limited © 2023</copyright>
+    <copyright>Top Marks Development Limited © 2024</copyright>
     <language>en-GB</language>
     <PackageTags>Expression Builder Func LINQ Lambda Database IQuery LINQ SQL LINQ2SQL Queryable</PackageTags>
     <releaseNotes>

--- a/Packages/Operations/NotEqual/src/Operations.NotEqual.Src.csproj
+++ b/Packages/Operations/NotEqual/src/Operations.NotEqual.Src.csproj
@@ -11,13 +11,13 @@
     <title>Expression Builder - Operation: NotEqual</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>
-    <licenseUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/LICENSE</licenseUrl>
-    <projectUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/ExpressionBuilder/Assets/icon.png</iconUrl>
+    <licenseUrl>https://github.com/TopMarksDevelopment/Expression-Builder/blob/main/LICENSE.md</licenseUrl>
+    <projectUrl>https://github.com/TopMarksDevelopment/Expression-Builder/</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/Expression-Builder/main/assets/icon.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <Description>The "NotEqual" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</Description>
     <summary>The "NotEqual" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</summary>
-    <copyright>Top Marks Development Limited © 2023</copyright>
+    <copyright>Top Marks Development Limited © 2024</copyright>
     <language>en-GB</language>
     <PackageTags>Expression Builder Func LINQ Lambda Database IQuery LINQ SQL LINQ2SQL Queryable</PackageTags>
     <releaseNotes>

--- a/Packages/Operations/NotIn/src/Operations.NotIn.Src.csproj
+++ b/Packages/Operations/NotIn/src/Operations.NotIn.Src.csproj
@@ -11,13 +11,13 @@
     <title>Expression Builder - Operation: NotIn</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>
-    <licenseUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/LICENSE</licenseUrl>
-    <projectUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/ExpressionBuilder/Assets/icon.png</iconUrl>
+    <licenseUrl>https://github.com/TopMarksDevelopment/Expression-Builder/blob/main/LICENSE.md</licenseUrl>
+    <projectUrl>https://github.com/TopMarksDevelopment/Expression-Builder/</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/Expression-Builder/main/assets/icon.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <Description>The "NotIn" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</Description>
     <summary>The "NotIn" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</summary>
-    <copyright>Top Marks Development Limited © 2023</copyright>
+    <copyright>Top Marks Development Limited © 2024</copyright>
     <language>en-GB</language>
     <PackageTags>Expression Builder Func LINQ Lambda Database IQuery LINQ SQL LINQ2SQL Queryable</PackageTags>
     <releaseNotes>

--- a/Packages/Operations/SmartSearch/src/Operations.SmartSearch.Src.csproj
+++ b/Packages/Operations/SmartSearch/src/Operations.SmartSearch.Src.csproj
@@ -11,13 +11,13 @@
     <title>Expression Builder - Operation: SmartSearch</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>
-    <licenseUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/LICENSE</licenseUrl>
-    <projectUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/ExpressionBuilder/Assets/icon.png</iconUrl>
+    <licenseUrl>https://github.com/TopMarksDevelopment/Expression-Builder/blob/main/LICENSE.md</licenseUrl>
+    <projectUrl>https://github.com/TopMarksDevelopment/Expression-Builder/</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/Expression-Builder/main/assets/icon.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <Description>The "SmartSearch" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</Description>
     <summary>The "SmartSearch" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</summary>
-    <copyright>Top Marks Development Limited © 2023</copyright>
+    <copyright>Top Marks Development Limited © 2024</copyright>
     <language>en-GB</language>
     <PackageTags>Expression Builder Func LINQ Lambda Database IQuery LINQ SQL LINQ2SQL Queryable</PackageTags>
     <releaseNotes>

--- a/Packages/Operations/StartsWith/src/Operations.StartsWith.Src.csproj
+++ b/Packages/Operations/StartsWith/src/Operations.StartsWith.Src.csproj
@@ -11,13 +11,13 @@
     <title>Expression Builder - Operation: StartsWith</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>
-    <licenseUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/LICENSE</licenseUrl>
-    <projectUrl>https://github.com/TopMarksDevelopment/ExpressionBuilder/</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/ExpressionBuilder/Assets/icon.png</iconUrl>
+    <licenseUrl>https://github.com/TopMarksDevelopment/Expression-Builder/blob/main/LICENSE.md</licenseUrl>
+    <projectUrl>https://github.com/TopMarksDevelopment/Expression-Builder/</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/TopMarksDevelopment/Expression-Builder/main/assets/icon.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <Description>The "StartsWith" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</Description>
     <summary>The "StartsWith" operation for the "ExpressionBuilder" package. ExpressionBuilder allows you to easily build a filter that can be applied to lists and database queries (even dynamically). Packed with features, you can: easily convert API requests into expressions, save and re-run filters, have `NULL` checks done  automatically, build complex queries with groups and so much more!</summary>
-    <copyright>Top Marks Development Limited © 2023</copyright>
+    <copyright>Top Marks Development Limited © 2024</copyright>
     <language>en-GB</language>
     <PackageTags>Expression Builder Func LINQ Lambda Database IQuery LINQ SQL LINQ2SQL Queryable</PackageTags>
     <releaseNotes>


### PR DESCRIPTION
### Package: TopMarksDevelopment.ExpressionBuilder(* All)

#### Fixed

-   Fixed the paths for the icons and the links to GitHub source code

#### Changed

-   Updated the copyright year for NuGet packages and `License.md`