### PR TITLE
v0.2.1-beta

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -25,9 +25,9 @@ All notable changes to this project will be documented in this file.
 
 > ❗ Whilst in the beta phase, breaking changes will happen between "minor" releases. Because of this, patches and new features will happen at between "patch" releases.
 
-## <!-- [0.2.1-beta] - -->UNPUBLISHED
+## [0.2.1-beta] - 2024-03-06
 
-<!-- <small>[Compare to previous release][comp:0.2.1-beta]</small> -->
+<small>[Compare to previous release][comp:0.2.1-beta]</small>
 
 ### Package: TopMarksDevelopment.ExpressionBuilder(* All)
 

--- a/Packages/Api/src/Api.Src.csproj
+++ b/Packages/Api/src/Api.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Api</PackageId>
-    <version>0.2.0-beta</version>
+    <version>0.2.1-beta</version>
     <title>Expression Builder (API)</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Core/src/Core.Src.csproj
+++ b/Packages/Core/src/Core.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Core</PackageId>
-    <version>0.2.0-beta</version>
+    <version>0.2.1-beta</version>
     <title>Expression Builder (Core Functionality)</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Main/src/Main.Src.csproj
+++ b/Packages/Main/src/Main.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder</PackageId>
-    <version>0.2.0-beta</version>
+    <version>0.2.1-beta</version>
     <title>Expression Builder</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/Between/src/Operations.Between.Src.csproj
+++ b/Packages/Operations/Between/src/Operations.Between.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.Between</PackageId>
-    <version>0.2.0-beta</version>
+    <version>0.2.1-beta</version>
     <title>Expression Builder - Operation: Between</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/BetweenExclusive/src/Operations.BetweenExclusive.Src.csproj
+++ b/Packages/Operations/BetweenExclusive/src/Operations.BetweenExclusive.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.BetweenExclusive</PackageId>
-    <version>0.2.0-beta</version>
+    <version>0.2.1-beta</version>
     <title>Expression Builder - Operation: BetweenExclusive</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/Contains/src/Operations.Contains.Src.csproj
+++ b/Packages/Operations/Contains/src/Operations.Contains.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.Contains</PackageId>
-    <version>0.2.0-beta</version>
+    <version>0.2.1-beta</version>
     <title>Expression Builder - Operation: Contains</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/DoesNotContain/src/Operations.DoesNotContain.Src.csproj
+++ b/Packages/Operations/DoesNotContain/src/Operations.DoesNotContain.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.DoesNotContain</PackageId>
-    <version>0.2.0-beta</version>
+    <version>0.2.1-beta</version>
     <title>Expression Builder - Operation: DoesNotContain</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/DoesNotEndWith/src/Operations.DoesNotEndWith.Src.csproj
+++ b/Packages/Operations/DoesNotEndWith/src/Operations.DoesNotEndWith.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.DoesNotEndWith</PackageId>
-    <version>0.2.0-beta</version>
+    <version>0.2.1-beta</version>
     <title>Expression Builder - Operation: DoesNotEndWith</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/DoesNotStartWith/src/Operations.DoesNotStartWith.Src.csproj
+++ b/Packages/Operations/DoesNotStartWith/src/Operations.DoesNotStartWith.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.DoesNotStartWith</PackageId>
-    <version>0.2.0-beta</version>
+    <version>0.2.1-beta</version>
     <title>Expression Builder - Operation: DoesNotStartWith</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/EndsWith/src/Operations.EndsWith.Src.csproj
+++ b/Packages/Operations/EndsWith/src/Operations.EndsWith.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.EndsWith</PackageId>
-    <version>0.2.0-beta</version>
+    <version>0.2.1-beta</version>
     <title>Expression Builder - Operation: EndsWith</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/Equal/src/Operations.Equal.Src.csproj
+++ b/Packages/Operations/Equal/src/Operations.Equal.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.Equal</PackageId>
-    <version>0.2.0-beta</version>
+    <version>0.2.1-beta</version>
     <title>Expression Builder - Operation: Equal</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/GreaterThan/src/Operations.GreaterThan.Src.csproj
+++ b/Packages/Operations/GreaterThan/src/Operations.GreaterThan.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.GreaterThan</PackageId>
-    <version>0.2.0-beta</version>
+    <version>0.2.1-beta</version>
     <title>Expression Builder - Operation: GreaterThan</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/GreaterThanOrEqual/src/Operations.GreaterThanOrEqual.Src.csproj
+++ b/Packages/Operations/GreaterThanOrEqual/src/Operations.GreaterThanOrEqual.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.GreaterThanOrEqual</PackageId>
-    <version>0.2.0-beta</version>
+    <version>0.2.1-beta</version>
     <title>Expression Builder - Operation: GreaterThanOrEqual</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/In/src/Operations.In.Src.csproj
+++ b/Packages/Operations/In/src/Operations.In.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.In</PackageId>
-    <version>0.2.0-beta</version>
+    <version>0.2.1-beta</version>
     <title>Expression Builder - Operation: In</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/IsEmpty/src/Operations.IsEmpty.Src.csproj
+++ b/Packages/Operations/IsEmpty/src/Operations.IsEmpty.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.IsEmpty</PackageId>
-    <version>0.2.0-beta</version>
+    <version>0.2.1-beta</version>
     <title>Expression Builder - Operation: IsEmpty</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/IsNotEmpty/src/Operations.IsNotEmpty.Src.csproj
+++ b/Packages/Operations/IsNotEmpty/src/Operations.IsNotEmpty.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.IsNotEmpty</PackageId>
-    <version>0.2.0-beta</version>
+    <version>0.2.1-beta</version>
     <title>Expression Builder - Operation: IsNotEmpty</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/IsNotNull/src/Operations.IsNotNull.Src.csproj
+++ b/Packages/Operations/IsNotNull/src/Operations.IsNotNull.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.IsNotNull</PackageId>
-    <version>0.2.0-beta</version>
+    <version>0.2.1-beta</version>
     <title>Expression Builder - Operation: IsNotNull</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/IsNotNullOrWhiteSpace/src/Operations.IsNotNullOrWhiteSpace.Src.csproj
+++ b/Packages/Operations/IsNotNullOrWhiteSpace/src/Operations.IsNotNullOrWhiteSpace.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.IsNotNullOrWhiteSpace</PackageId>
-    <version>0.2.0-beta</version>
+    <version>0.2.1-beta</version>
     <title>Expression Builder - Operation: IsNotNullOrWhiteSpace</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/IsNull/src/Operations.IsNull.Src.csproj
+++ b/Packages/Operations/IsNull/src/Operations.IsNull.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.IsNull</PackageId>
-    <version>0.2.0-beta</version>
+    <version>0.2.1-beta</version>
     <title>Expression Builder - Operation: IsNull</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/IsNullOrWhiteSpace/src/Operations.IsNullOrWhiteSpace.Src.csproj
+++ b/Packages/Operations/IsNullOrWhiteSpace/src/Operations.IsNullOrWhiteSpace.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.IsNullOrWhiteSpace</PackageId>
-    <version>0.2.0-beta</version>
+    <version>0.2.1-beta</version>
     <title>Expression Builder - Operation: IsNullOrWhiteSpace</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/LessThan/src/Operations.LessThan.Src.csproj
+++ b/Packages/Operations/LessThan/src/Operations.LessThan.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.LessThan</PackageId>
-    <version>0.2.0-beta</version>
+    <version>0.2.1-beta</version>
     <title>Expression Builder - Operation: LessThan</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/LessThanOrEqual/src/Operations.LessThanOrEqual.Src.csproj
+++ b/Packages/Operations/LessThanOrEqual/src/Operations.LessThanOrEqual.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.LessThanOrEqual</PackageId>
-    <version>0.2.0-beta</version>
+    <version>0.2.1-beta</version>
     <title>Expression Builder - Operation: LessThanOrEqual</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/NotBetween/src/Operations.NotBetween.Src.csproj
+++ b/Packages/Operations/NotBetween/src/Operations.NotBetween.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.NotBetween</PackageId>
-    <version>0.2.0-beta</version>
+    <version>0.2.1-beta</version>
     <title>Expression Builder - Operation: NotBetween</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/NotBetweenExclusive/src/Operations.NotBetweenExclusive.Src.csproj
+++ b/Packages/Operations/NotBetweenExclusive/src/Operations.NotBetweenExclusive.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.NotBetweenExclusive</PackageId>
-    <version>0.2.0-beta</version>
+    <version>0.2.1-beta</version>
     <title>Expression Builder - Operation: NotBetweenExclusive</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/NotEqual/src/Operations.NotEqual.Src.csproj
+++ b/Packages/Operations/NotEqual/src/Operations.NotEqual.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.NotEqual</PackageId>
-    <version>0.2.0-beta</version>
+    <version>0.2.1-beta</version>
     <title>Expression Builder - Operation: NotEqual</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/NotIn/src/Operations.NotIn.Src.csproj
+++ b/Packages/Operations/NotIn/src/Operations.NotIn.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.NotIn</PackageId>
-    <version>0.2.0-beta</version>
+    <version>0.2.1-beta</version>
     <title>Expression Builder - Operation: NotIn</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/SmartSearch/src/Operations.SmartSearch.Src.csproj
+++ b/Packages/Operations/SmartSearch/src/Operations.SmartSearch.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.SmartSearch</PackageId>
-    <version>0.2.0-beta</version>
+    <version>0.2.1-beta</version>
     <title>Expression Builder - Operation: SmartSearch</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/StartsWith/src/Operations.StartsWith.Src.csproj
+++ b/Packages/Operations/StartsWith/src/Operations.StartsWith.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.StartsWith</PackageId>
-    <version>0.2.0-beta</version>
+    <version>0.2.1-beta</version>
     <title>Expression Builder - Operation: StartsWith</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Expression Builder
 
-[![An icon showing the status of the most recent completed test run](https://github.com/TopMarksDevelopment/Expression-Builder/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/TopMarksDevelopment/Expression-Builder/actions/workflows/build-and-test.yml)
+[![Icon for GitHub actions workflow status](https://img.shields.io/github/actions/workflow/status/TopMarksDevelopment/Expression-Builder/build-and-test.yml?style=for-the-badge)](https://github.com/TopMarksDevelopment/Expression-Builder/actions/workflows/build-and-test.yml)
+[![Icon for NuGetVersion](https://img.shields.io/nuget/v/TopMarksDevelopment.ExpressionBuilder?style=for-the-badge)](https://www.nuget.org/packages/TopMarksDevelopment.ExpressionBuilder)
+[![Icon for NuGetVersion](https://img.shields.io/nuget/dt/TopMarksDevelopment.ExpressionBuilder?style=for-the-badge)](https://www.nuget.org/packages/TopMarksDevelopment.ExpressionBuilder)
 
 If you're looking for a library to help you easily build lambda expressions, look no further than the **Expression Builder** package. With this library you can quickly create a filter that can be applied to lists and database queries; even dynamically. Plus, it's packed with some great features too!
 


### PR DESCRIPTION
# 0.2.1-beta - 2024-03-06

<small>[Compare to previous release][comp:0.2.1-beta]</small>

### Package: TopMarksDevelopment.ExpressionBuilder(* All)

#### Fixed

-   Fixed the paths for the icons and the links to GitHub source code

#### Changed

-   Updated the copyright year for NuGet packages and `License.md`

### Package: TopMarksDevelopment.ExpressionBuilder.Operations.* (All Operations)

#### Changed

-   Moved all extension methods from the `TopMarksDevelopment.ExpressionBuilder.Api` namespace to `TopMarksDevelopment.ExpressionBuilder`, for easier access _(not technically "breaking" as the main package is always required to operate)_

[comp:0.2.1-beta]: https://github.com/TopMarksDevelopment/Expression-Builder/compare/v0.2.0-beta...v0.2.1-beta