### PR TITLE
Stop unnecessary null conversion

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,13 +23,21 @@ Types of changes
 
 All notable changes to this project will be documented in this file.
 
-> ❗ Whilst in the beta phase, breaking changes will happen between "minor" releases. Because of this, patches and new features will happen at between "patch" releases.
+> ❗ Whilst in the beta phase, breaking changes will happen between "minor" releases. Because of this, patches and new features will happen between "patch" releases
+
+## UNPUBLISHED
+
+### Package: TopMarksDevelopment.ExpressionBuilder.Operations.In
+
+#### Fixed
+
+-   We no longer try to convert `members` to nullable types if they're already nullable
 
 ## [0.2.1-beta] - 2024-03-06
 
 <small>[Compare to previous release][comp:0.2.1-beta]</small>
 
-### Package: TopMarksDevelopment.ExpressionBuilder(* All)
+### Package: TopMarksDevelopment.ExpressionBuilder(\* All)
 
 #### Fixed
 
@@ -39,7 +47,7 @@ All notable changes to this project will be documented in this file.
 
 -   Updated the copyright year for NuGet packages and `License.md`
 
-### Package: TopMarksDevelopment.ExpressionBuilder.Operations.* (All Operations)
+### Package: TopMarksDevelopment.ExpressionBuilder.Operations.\* (All Operations)
 
 #### Changed
 

--- a/Packages/Operations/Equal/src/Equal.cs
+++ b/Packages/Operations/Equal/src/Equal.cs
@@ -20,7 +20,7 @@ public partial struct Equal : IOperation
         IFilterCollection<TPropertyType?> values,
         IEnumerable<IEntityManipulator>? manipulators
     ) =>
-        values.Count() > 1
+        values.Count > 1
             ? new In() { Match = Match }.Build(member, values, manipulators)
             : Expression.Equal(member, Expression.Constant(values.First()));
 

--- a/Packages/Operations/In/src/In.cs
+++ b/Packages/Operations/In/src/In.cs
@@ -34,7 +34,7 @@ public struct In : IOperation
             containsMethod,
             Nullable.GetUnderlyingType(
                 containsMethod.ReflectedType!.GenericTypeArguments[0]
-            ) == null
+            ) == null || member.Type == typeof(TPropertyType?)
                 ? member
                 : Expression.Convert(member, typeof(TPropertyType?))
         );


### PR DESCRIPTION
### Package: TopMarksDevelopment.ExpressionBuilder.Operations.In

#### Fixed

-   We no longer try to convert `members` to nullable types if they're already nullable