### PR TITLE
v0.3.0-beta

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -25,7 +25,9 @@ All notable changes to this project will be documented in this file.
 
 > ❗ Whilst in the beta phase, breaking changes will happen between "minor" releases. Because of this, patches and new features will happen between "patch" releases
 
-## UNPUBLISHED
+## [0.3.0-beta] - 2024-04-25
+
+<small>[Compare to previous release][comp:0.3.0-beta]</small>
 
 ### Breaking Changes (Overview)
 
@@ -255,6 +257,8 @@ This needs to be revisited, read the [discussion](https://github.com/TopMarksDev
 
 **Initial release**
 
+[0.3.0-beta]: https://github.com/TopMarksDevelopment/Expression-Builder/releases/tag/v0.3.0-beta
+[comp:0.3.0-beta]: https://github.com/TopMarksDevelopment/Expression-Builder/compare/v0.2.1-beta...v0.3.0-beta
 [0.2.1-beta]: https://github.com/TopMarksDevelopment/Expression-Builder/releases/tag/v0.2.1-beta
 [comp:0.2.1-beta]: https://github.com/TopMarksDevelopment/Expression-Builder/compare/v0.2.0-beta...v0.2.1-beta
 [0.2.0-beta]: https://github.com/TopMarksDevelopment/Expression-Builder/releases/tag/v0.2.0-beta

--- a/Packages/Api/src/Api.Src.csproj
+++ b/Packages/Api/src/Api.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Api</PackageId>
-    <version>0.2.1-beta</version>
+    <version>0.3.0-beta</version>
     <title>Expression Builder (API)</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Core/src/Core.Src.csproj
+++ b/Packages/Core/src/Core.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Core</PackageId>
-    <version>0.2.1-beta</version>
+    <version>0.3.0-beta</version>
     <title>Expression Builder (Core Functionality)</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Main/src/Main.Src.csproj
+++ b/Packages/Main/src/Main.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder</PackageId>
-    <version>0.2.1-beta</version>
+    <version>0.3.0-beta</version>
     <title>Expression Builder</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/Between/src/Operations.Between.Src.csproj
+++ b/Packages/Operations/Between/src/Operations.Between.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.Between</PackageId>
-    <version>0.2.1-beta</version>
+    <version>0.3.0-beta</version>
     <title>Expression Builder - Operation: Between</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/BetweenExclusive/src/Operations.BetweenExclusive.Src.csproj
+++ b/Packages/Operations/BetweenExclusive/src/Operations.BetweenExclusive.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.BetweenExclusive</PackageId>
-    <version>0.2.1-beta</version>
+    <version>0.3.0-beta</version>
     <title>Expression Builder - Operation: BetweenExclusive</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/Contains/src/Operations.Contains.Src.csproj
+++ b/Packages/Operations/Contains/src/Operations.Contains.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.Contains</PackageId>
-    <version>0.2.1-beta</version>
+    <version>0.3.0-beta</version>
     <title>Expression Builder - Operation: Contains</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/DoesNotContain/src/Operations.DoesNotContain.Src.csproj
+++ b/Packages/Operations/DoesNotContain/src/Operations.DoesNotContain.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.DoesNotContain</PackageId>
-    <version>0.2.1-beta</version>
+    <version>0.3.0-beta</version>
     <title>Expression Builder - Operation: DoesNotContain</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/DoesNotEndWith/src/Operations.DoesNotEndWith.Src.csproj
+++ b/Packages/Operations/DoesNotEndWith/src/Operations.DoesNotEndWith.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.DoesNotEndWith</PackageId>
-    <version>0.2.1-beta</version>
+    <version>0.3.0-beta</version>
     <title>Expression Builder - Operation: DoesNotEndWith</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/DoesNotStartWith/src/Operations.DoesNotStartWith.Src.csproj
+++ b/Packages/Operations/DoesNotStartWith/src/Operations.DoesNotStartWith.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.DoesNotStartWith</PackageId>
-    <version>0.2.1-beta</version>
+    <version>0.3.0-beta</version>
     <title>Expression Builder - Operation: DoesNotStartWith</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/EndsWith/src/Operations.EndsWith.Src.csproj
+++ b/Packages/Operations/EndsWith/src/Operations.EndsWith.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.EndsWith</PackageId>
-    <version>0.2.1-beta</version>
+    <version>0.3.0-beta</version>
     <title>Expression Builder - Operation: EndsWith</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/Equal/src/Operations.Equal.Src.csproj
+++ b/Packages/Operations/Equal/src/Operations.Equal.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.Equal</PackageId>
-    <version>0.2.1-beta</version>
+    <version>0.3.0-beta</version>
     <title>Expression Builder - Operation: Equal</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/GreaterThan/src/Operations.GreaterThan.Src.csproj
+++ b/Packages/Operations/GreaterThan/src/Operations.GreaterThan.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.GreaterThan</PackageId>
-    <version>0.2.1-beta</version>
+    <version>0.3.0-beta</version>
     <title>Expression Builder - Operation: GreaterThan</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/GreaterThanOrEqual/src/Operations.GreaterThanOrEqual.Src.csproj
+++ b/Packages/Operations/GreaterThanOrEqual/src/Operations.GreaterThanOrEqual.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.GreaterThanOrEqual</PackageId>
-    <version>0.2.1-beta</version>
+    <version>0.3.0-beta</version>
     <title>Expression Builder - Operation: GreaterThanOrEqual</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/In/src/Operations.In.Src.csproj
+++ b/Packages/Operations/In/src/Operations.In.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.In</PackageId>
-    <version>0.2.1-beta</version>
+    <version>0.3.0-beta</version>
     <title>Expression Builder - Operation: In</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/IsEmpty/src/Operations.IsEmpty.Src.csproj
+++ b/Packages/Operations/IsEmpty/src/Operations.IsEmpty.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.IsEmpty</PackageId>
-    <version>0.2.1-beta</version>
+    <version>0.3.0-beta</version>
     <title>Expression Builder - Operation: IsEmpty</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/IsNotEmpty/src/Operations.IsNotEmpty.Src.csproj
+++ b/Packages/Operations/IsNotEmpty/src/Operations.IsNotEmpty.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.IsNotEmpty</PackageId>
-    <version>0.2.1-beta</version>
+    <version>0.3.0-beta</version>
     <title>Expression Builder - Operation: IsNotEmpty</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/IsNotNull/src/Operations.IsNotNull.Src.csproj
+++ b/Packages/Operations/IsNotNull/src/Operations.IsNotNull.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.IsNotNull</PackageId>
-    <version>0.2.1-beta</version>
+    <version>0.3.0-beta</version>
     <title>Expression Builder - Operation: IsNotNull</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/IsNotNullOrWhiteSpace/src/Operations.IsNotNullOrWhiteSpace.Src.csproj
+++ b/Packages/Operations/IsNotNullOrWhiteSpace/src/Operations.IsNotNullOrWhiteSpace.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.IsNotNullOrWhiteSpace</PackageId>
-    <version>0.2.1-beta</version>
+    <version>0.3.0-beta</version>
     <title>Expression Builder - Operation: IsNotNullOrWhiteSpace</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/IsNull/src/Operations.IsNull.Src.csproj
+++ b/Packages/Operations/IsNull/src/Operations.IsNull.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.IsNull</PackageId>
-    <version>0.2.1-beta</version>
+    <version>0.3.0-beta</version>
     <title>Expression Builder - Operation: IsNull</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/IsNullOrWhiteSpace/src/Operations.IsNullOrWhiteSpace.Src.csproj
+++ b/Packages/Operations/IsNullOrWhiteSpace/src/Operations.IsNullOrWhiteSpace.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.IsNullOrWhiteSpace</PackageId>
-    <version>0.2.1-beta</version>
+    <version>0.3.0-beta</version>
     <title>Expression Builder - Operation: IsNullOrWhiteSpace</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/LessThan/src/Operations.LessThan.Src.csproj
+++ b/Packages/Operations/LessThan/src/Operations.LessThan.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.LessThan</PackageId>
-    <version>0.2.1-beta</version>
+    <version>0.3.0-beta</version>
     <title>Expression Builder - Operation: LessThan</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/LessThanOrEqual/src/Operations.LessThanOrEqual.Src.csproj
+++ b/Packages/Operations/LessThanOrEqual/src/Operations.LessThanOrEqual.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.LessThanOrEqual</PackageId>
-    <version>0.2.1-beta</version>
+    <version>0.3.0-beta</version>
     <title>Expression Builder - Operation: LessThanOrEqual</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/NotBetween/src/Operations.NotBetween.Src.csproj
+++ b/Packages/Operations/NotBetween/src/Operations.NotBetween.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.NotBetween</PackageId>
-    <version>0.2.1-beta</version>
+    <version>0.3.0-beta</version>
     <title>Expression Builder - Operation: NotBetween</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/NotBetweenExclusive/src/Operations.NotBetweenExclusive.Src.csproj
+++ b/Packages/Operations/NotBetweenExclusive/src/Operations.NotBetweenExclusive.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.NotBetweenExclusive</PackageId>
-    <version>0.2.1-beta</version>
+    <version>0.3.0-beta</version>
     <title>Expression Builder - Operation: NotBetweenExclusive</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/NotEqual/src/Operations.NotEqual.Src.csproj
+++ b/Packages/Operations/NotEqual/src/Operations.NotEqual.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.NotEqual</PackageId>
-    <version>0.2.1-beta</version>
+    <version>0.3.0-beta</version>
     <title>Expression Builder - Operation: NotEqual</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/NotIn/src/Operations.NotIn.Src.csproj
+++ b/Packages/Operations/NotIn/src/Operations.NotIn.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.NotIn</PackageId>
-    <version>0.2.1-beta</version>
+    <version>0.3.0-beta</version>
     <title>Expression Builder - Operation: NotIn</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/SmartSearch/src/Operations.SmartSearch.Src.csproj
+++ b/Packages/Operations/SmartSearch/src/Operations.SmartSearch.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.SmartSearch</PackageId>
-    <version>0.2.1-beta</version>
+    <version>0.3.0-beta</version>
     <title>Expression Builder - Operation: SmartSearch</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/StartsWith/src/Operations.StartsWith.Src.csproj
+++ b/Packages/Operations/StartsWith/src/Operations.StartsWith.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.StartsWith</PackageId>
-    <version>0.2.1-beta</version>
+    <version>0.3.0-beta</version>
     <title>Expression Builder - Operation: StartsWith</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>


### PR DESCRIPTION
# 0.3.0-beta - 2024-04-25

<small>[Compare to previous release][comp:0.3.0-beta]</small>

### Breaking Changes (Overview)

-   `IFilterStatement`
    -   Now has an `Options` property
        This allows serialising to retain options applied to filters
    -   `Manipulators` has moved into the new `Options` property
-   `IEntityManipulator`
    -   Now requires methods to manipulate Properties/Fields AND raw values
-   `IOperation`
    -   Has new `Defaults` property
    -   `Match` has moved into `Defaults`
    -   `SkipNullMemberChecks` has moved into `Defaults` and is now called `NullHandler`
-   Operations can no longer have their null handler customised
This needs to be revisited, read the [discussion](https://github.com/TopMarksDevelopment/Expression-Builder/discussions/14)
-   Serialisation
    -   To accommodate the changes above, we now serialise `Options` - meaning current `Manipulators` will be lost.
    -   Serialisation could break if the order of types was different. To prevent this there is now a default order and a `TypeTracker.FilterStatementTypes` static property for customisation
-   `Equal` and `NotEqual`
    -   No longer do pre-emptive null checks as checking `null` is excluding actual matches
-   `DoesNotContain`, `DoesNotEndWith`, `DoesNotStartWith`
    -   Now do a pre-emptive "is null OR" check as it was excluding `null`s

### Package: TopMarksDevelopment.ExpressionBuilder(\* All)

#### Fixed

-   Actually fixed the paths for the icons and the links to GitHub source code

#### Changed

-   Compressed `icon.png` to reduce package size increase

### Package: TopMarksDevelopment.ExpressionBuilder.Operations.\*Not\* (All Not Operations)

#### Changes

-   Barring `NotIn`, all `Not` operations no longer rely on their counter operation. This was just unnecessary as the expression access was often simpler

### Package: TopMarksDevelopment.ExpressionBuilder.Operations.\* (All Operations)

#### Breaking changes

-   Reflected the changes made to `IOperation`:
    -   Has new `Defaults` property. `Match` has moved into `Defaults`. `SkipNullMemberChecks` has moved into `Defaults` and is now called `NullHandler`

### Package: TopMarksDevelopment.ExpressionBuilder.Api

#### Breaking changes

-   Made changes made to `IOperation`:
    -   Has new `Defaults` property. `Match` has moved into `Defaults`. `SkipNullMemberChecks` has moved into `Defaults` and is now called `NullHandler`

### Package: TopMarksDevelopment.ExpressionBuilder.Core

#### Breaking changes

-   Serialisation could break if the order of types was different. To prevent this there is now a default order and a `TypeTracker.FilterStatementTypes` static property for customisation

#### Fixed

-   Calling `ToString` on a manipulator now produces with the correct output string.
-   Manipulators that cause an underlying type change no longer throws an exception
-   Serialisation now adds core items based on the non-existence of `IFilterItem` rather than based on the values in the old `ProtoTypes` meaning serialisation could break in certain scenarios
-   Assigning an `OpenCollection` to a variable, then calling a further `OpenCollection` and `CloseCollection` in a chain would leave the variable in the `OpenCollection` state. This would apply further filters to the wrong class/property causing errors/miss-results

### Package: TopMarksDevelopment.ExpressionBuilder.Operations.DoesNotContain

#### Breaking changes

-   Tweaked null check to allow null or a match. As results are excluded if they're null

#### Changes

-   No longer depends on `Contains`

### Package: TopMarksDevelopment.ExpressionBuilder.Operations.DoesNotEndWith

#### Breaking changes

-   Tweaked null check to allow null or a match. As results are excluded if they're null

#### Changes

-   No longer depends on `EndsWith`

### Package: TopMarksDevelopment.ExpressionBuilder.Operations.DoesNotStartWith

#### Breaking changes

-   Tweaked null check to allow null or a match. As results are excluded if they're null

#### Changes

-   No longer depends on `StartsWith`

### Package: TopMarksDevelopment.ExpressionBuilder.Operations.Equal

#### Breaking changes

-   No longer does a null check first. As matching null will always return nothing

### Package: TopMarksDevelopment.ExpressionBuilder.Operations.In

#### Fixed

-   We no longer try to convert `members` to nullable types if they're already nullable

### Package: TopMarksDevelopment.ExpressionBuilder.Operations.IsNotEmpty

#### Breaking changes

-   Tweaked null check to allow null or a match. As results are excluded if they're null

#### Changes

-   No longer depends on `IsEmpty`

### Package: TopMarksDevelopment.ExpressionBuilder.Operations.IsNotNull

#### Changes

-   No longer depends on `IsNull`

### Package: TopMarksDevelopment.ExpressionBuilder.Operations.IsNotNullOrWhiteSpace

#### Changes

-   No longer depends on `IsNullOrWhiteSpace`

### Package: TopMarksDevelopment.ExpressionBuilder.Operations.NotBetween

#### Breaking changes

-   Tweaked null check to allow null or a match. As results are excluded if they're null

#### Changes

-   No longer depends on `Between`

### Package: TopMarksDevelopment.ExpressionBuilder.Operations.NotBetweenExclusive

#### Breaking changes

-   Tweaked null check to allow null or a match. As results are excluded if they're null

#### Changes

-   No longer depends on `BetweenExclusive`

### Package: TopMarksDevelopment.ExpressionBuilder.Operations.NotEqual

#### Breaking changes

-   No longer does a null check first. As results are excluded if they're null

### Package: TopMarksDevelopment.ExpressionBuilder.Operations.NotIn

#### Breaking changes

-   Tweaked null check to allow null or a match. As results are excluded if they're null

### Other (none-user facing)

#### Added

-   Completed adding all tests for the rest of the operations. Closes: [#1](https://github.com/TopMarksDevelopment/Expression-Builder/issues/1)
-   Added more tests to:
    -   `Core` package
    -   all the `Between` operations
    -   `DoesNotContain` operation
    -   `In` operation
    -   `NotIn` operation
    -   `SmartSearch` operation

#### Changes

-   To better identify and maintain tests that have been added after a fix, they have all been extracted into their own `Fix-Tests.cs` class - this should be the de facto moving forward
-   Converted tests to the preferred `TheroyData` method
-   Removed tests that are related to the (for-now) removed `SkipNullChecks` option
-   Improved on `build-and-test` by correcting `--no-restore` to `--no-build` during the test phase

[comp:0.3.0-beta]: https://github.com/TopMarksDevelopment/Expression-Builder/compare/v0.2.1-beta...v0.3.0-beta