### PR TITLE
v0.4.0-beta

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -39,7 +39,7 @@ All notable changes to this project will be documented in this file.
 
 -   `IFilter` now requires a `Current` list to show the collection it's currently working on. This means that close chaining works better
 
-### Added
+#### Added
 
 -   Added summary blocks to all the interfaces (Chore: more to do)
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -25,7 +25,9 @@ All notable changes to this project will be documented in this file.
 
 > ❗ Whilst in the beta phase, breaking changes will happen between "minor" releases. Because of this, patches and new features will happen between "patch" releases
 
-## Unreleased
+## [0.4.0-beta] - 2024-04-26
+
+<small>[Compare to previous release][comp:0.4.0-beta]</small>
 
 ### Breaking Changes (Overview)
 
@@ -287,6 +289,8 @@ All notable changes to this project will be documented in this file.
 
 **Initial release**
 
+[0.4.0-beta]: https://github.com/TopMarksDevelopment/Expression-Builder/releases/tag/v0.4.0-beta
+[comp:0.4.0-beta]: https://github.com/TopMarksDevelopment/Expression-Builder/compare/v0.3.0-beta...v0.4.0-beta
 [0.3.0-beta]: https://github.com/TopMarksDevelopment/Expression-Builder/releases/tag/v0.3.0-beta
 [comp:0.3.0-beta]: https://github.com/TopMarksDevelopment/Expression-Builder/compare/v0.2.1-beta...v0.3.0-beta
 [0.2.1-beta]: https://github.com/TopMarksDevelopment/Expression-Builder/releases/tag/v0.2.1-beta

--- a/Packages/Api/src/Api.Src.csproj
+++ b/Packages/Api/src/Api.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Api</PackageId>
-    <version>0.3.0-beta</version>
+    <version>0.4.0-beta</version>
     <title>Expression Builder (API)</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Core/src/Core.Src.csproj
+++ b/Packages/Core/src/Core.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Core</PackageId>
-    <version>0.3.0-beta</version>
+    <version>0.4.0-beta</version>
     <title>Expression Builder (Core Functionality)</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Main/src/Main.Src.csproj
+++ b/Packages/Main/src/Main.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder</PackageId>
-    <version>0.3.0-beta</version>
+    <version>0.4.0-beta</version>
     <title>Expression Builder</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/Between/src/Operations.Between.Src.csproj
+++ b/Packages/Operations/Between/src/Operations.Between.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.Between</PackageId>
-    <version>0.3.0-beta</version>
+    <version>0.4.0-beta</version>
     <title>Expression Builder - Operation: Between</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/BetweenExclusive/src/Operations.BetweenExclusive.Src.csproj
+++ b/Packages/Operations/BetweenExclusive/src/Operations.BetweenExclusive.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.BetweenExclusive</PackageId>
-    <version>0.3.0-beta</version>
+    <version>0.4.0-beta</version>
     <title>Expression Builder - Operation: BetweenExclusive</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/Contains/src/Operations.Contains.Src.csproj
+++ b/Packages/Operations/Contains/src/Operations.Contains.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.Contains</PackageId>
-    <version>0.3.0-beta</version>
+    <version>0.4.0-beta</version>
     <title>Expression Builder - Operation: Contains</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/DoesNotContain/src/Operations.DoesNotContain.Src.csproj
+++ b/Packages/Operations/DoesNotContain/src/Operations.DoesNotContain.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.DoesNotContain</PackageId>
-    <version>0.3.0-beta</version>
+    <version>0.4.0-beta</version>
     <title>Expression Builder - Operation: DoesNotContain</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/DoesNotEndWith/src/Operations.DoesNotEndWith.Src.csproj
+++ b/Packages/Operations/DoesNotEndWith/src/Operations.DoesNotEndWith.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.DoesNotEndWith</PackageId>
-    <version>0.3.0-beta</version>
+    <version>0.4.0-beta</version>
     <title>Expression Builder - Operation: DoesNotEndWith</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/DoesNotStartWith/src/Operations.DoesNotStartWith.Src.csproj
+++ b/Packages/Operations/DoesNotStartWith/src/Operations.DoesNotStartWith.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.DoesNotStartWith</PackageId>
-    <version>0.3.0-beta</version>
+    <version>0.4.0-beta</version>
     <title>Expression Builder - Operation: DoesNotStartWith</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/EndsWith/src/Operations.EndsWith.Src.csproj
+++ b/Packages/Operations/EndsWith/src/Operations.EndsWith.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.EndsWith</PackageId>
-    <version>0.3.0-beta</version>
+    <version>0.4.0-beta</version>
     <title>Expression Builder - Operation: EndsWith</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/Equal/src/Operations.Equal.Src.csproj
+++ b/Packages/Operations/Equal/src/Operations.Equal.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.Equal</PackageId>
-    <version>0.3.0-beta</version>
+    <version>0.4.0-beta</version>
     <title>Expression Builder - Operation: Equal</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/GreaterThan/src/Operations.GreaterThan.Src.csproj
+++ b/Packages/Operations/GreaterThan/src/Operations.GreaterThan.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.GreaterThan</PackageId>
-    <version>0.3.0-beta</version>
+    <version>0.4.0-beta</version>
     <title>Expression Builder - Operation: GreaterThan</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/GreaterThanOrEqual/src/Operations.GreaterThanOrEqual.Src.csproj
+++ b/Packages/Operations/GreaterThanOrEqual/src/Operations.GreaterThanOrEqual.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.GreaterThanOrEqual</PackageId>
-    <version>0.3.0-beta</version>
+    <version>0.4.0-beta</version>
     <title>Expression Builder - Operation: GreaterThanOrEqual</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/In/src/Operations.In.Src.csproj
+++ b/Packages/Operations/In/src/Operations.In.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.In</PackageId>
-    <version>0.3.0-beta</version>
+    <version>0.4.0-beta</version>
     <title>Expression Builder - Operation: In</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/IsEmpty/src/Operations.IsEmpty.Src.csproj
+++ b/Packages/Operations/IsEmpty/src/Operations.IsEmpty.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.IsEmpty</PackageId>
-    <version>0.3.0-beta</version>
+    <version>0.4.0-beta</version>
     <title>Expression Builder - Operation: IsEmpty</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/IsNotEmpty/src/Operations.IsNotEmpty.Src.csproj
+++ b/Packages/Operations/IsNotEmpty/src/Operations.IsNotEmpty.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.IsNotEmpty</PackageId>
-    <version>0.3.0-beta</version>
+    <version>0.4.0-beta</version>
     <title>Expression Builder - Operation: IsNotEmpty</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/IsNotNull/src/Operations.IsNotNull.Src.csproj
+++ b/Packages/Operations/IsNotNull/src/Operations.IsNotNull.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.IsNotNull</PackageId>
-    <version>0.3.0-beta</version>
+    <version>0.4.0-beta</version>
     <title>Expression Builder - Operation: IsNotNull</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/IsNotNullOrWhiteSpace/src/Operations.IsNotNullOrWhiteSpace.Src.csproj
+++ b/Packages/Operations/IsNotNullOrWhiteSpace/src/Operations.IsNotNullOrWhiteSpace.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.IsNotNullOrWhiteSpace</PackageId>
-    <version>0.3.0-beta</version>
+    <version>0.4.0-beta</version>
     <title>Expression Builder - Operation: IsNotNullOrWhiteSpace</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/IsNull/src/Operations.IsNull.Src.csproj
+++ b/Packages/Operations/IsNull/src/Operations.IsNull.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.IsNull</PackageId>
-    <version>0.3.0-beta</version>
+    <version>0.4.0-beta</version>
     <title>Expression Builder - Operation: IsNull</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/IsNullOrWhiteSpace/src/Operations.IsNullOrWhiteSpace.Src.csproj
+++ b/Packages/Operations/IsNullOrWhiteSpace/src/Operations.IsNullOrWhiteSpace.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.IsNullOrWhiteSpace</PackageId>
-    <version>0.3.0-beta</version>
+    <version>0.4.0-beta</version>
     <title>Expression Builder - Operation: IsNullOrWhiteSpace</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/LessThan/src/Operations.LessThan.Src.csproj
+++ b/Packages/Operations/LessThan/src/Operations.LessThan.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.LessThan</PackageId>
-    <version>0.3.0-beta</version>
+    <version>0.4.0-beta</version>
     <title>Expression Builder - Operation: LessThan</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/LessThanOrEqual/src/Operations.LessThanOrEqual.Src.csproj
+++ b/Packages/Operations/LessThanOrEqual/src/Operations.LessThanOrEqual.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.LessThanOrEqual</PackageId>
-    <version>0.3.0-beta</version>
+    <version>0.4.0-beta</version>
     <title>Expression Builder - Operation: LessThanOrEqual</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/NotBetween/src/Operations.NotBetween.Src.csproj
+++ b/Packages/Operations/NotBetween/src/Operations.NotBetween.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.NotBetween</PackageId>
-    <version>0.3.0-beta</version>
+    <version>0.4.0-beta</version>
     <title>Expression Builder - Operation: NotBetween</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/NotBetweenExclusive/src/Operations.NotBetweenExclusive.Src.csproj
+++ b/Packages/Operations/NotBetweenExclusive/src/Operations.NotBetweenExclusive.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.NotBetweenExclusive</PackageId>
-    <version>0.3.0-beta</version>
+    <version>0.4.0-beta</version>
     <title>Expression Builder - Operation: NotBetweenExclusive</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/NotEqual/src/Operations.NotEqual.Src.csproj
+++ b/Packages/Operations/NotEqual/src/Operations.NotEqual.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.NotEqual</PackageId>
-    <version>0.3.0-beta</version>
+    <version>0.4.0-beta</version>
     <title>Expression Builder - Operation: NotEqual</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/NotIn/src/Operations.NotIn.Src.csproj
+++ b/Packages/Operations/NotIn/src/Operations.NotIn.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.NotIn</PackageId>
-    <version>0.3.0-beta</version>
+    <version>0.4.0-beta</version>
     <title>Expression Builder - Operation: NotIn</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/SmartSearch/src/Operations.SmartSearch.Src.csproj
+++ b/Packages/Operations/SmartSearch/src/Operations.SmartSearch.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.SmartSearch</PackageId>
-    <version>0.3.0-beta</version>
+    <version>0.4.0-beta</version>
     <title>Expression Builder - Operation: SmartSearch</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/StartsWith/src/Operations.StartsWith.Src.csproj
+++ b/Packages/Operations/StartsWith/src/Operations.StartsWith.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.StartsWith</PackageId>
-    <version>0.3.0-beta</version>
+    <version>0.4.0-beta</version>
     <title>Expression Builder - Operation: StartsWith</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>


### PR DESCRIPTION
# 0.4.0-beta - 2024-04-26

<small>[Compare to previous release][comp:0.4.0-beta]</small>

### Breaking Changes (Overview)

-   `IFilter` now requires a `Current` list to show the collection it's currently working on. This means that close chaining works better

### Package: TopMarksDevelopment.ExpressionBuilder.Api

#### Breaking changes

-   `IFilter` now requires a `Current` list to show the collection it's currently working on. This means that close chaining works better

### Added

-   Added summary blocks to all the interfaces (Chore: more to do)

### Package: TopMarksDevelopment.ExpressionBuilder.Core

#### Fixed

-   Close chaining no longer carries through to the root filer.
    _Fixes bug introduced in v0.3.0-beta_

#### Changes

-   Implemented new `IFilter.Current` property
-   Added test for some deeper close chaining
    (as it's not a fix, but rather a check, it's in core-tests)
-   Removed some summary blocks that had been moved to the `Api` package

[comp:0.4.0-beta]: https://github.com/TopMarksDevelopment/Expression-Builder/compare/v0.3.0-beta...v0.4.0-beta