### PR TITLE
PREP: v1.0.0-rc.1

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,8 +23,6 @@ Types of changes
 
 All notable changes to this project will be documented in this file.
 
-> ❗ Whilst in the beta phase, breaking changes will happen between "minor" releases. Because of this, patches and new features will happen between "patch" releases
-
 ## [1.0.0-rc.1] - 2024-09-19
 
 <small>[Compare to previous release][comp:1.0.0-rc.1]</small>

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -25,7 +25,11 @@ All notable changes to this project will be documented in this file.
 
 > ❗ Whilst in the beta phase, breaking changes will happen between "minor" releases. Because of this, patches and new features will happen between "patch" releases
 
-## UNPUBLISHED
+## [1.0.0-rc.1] - 2024-09-19
+
+<small>[Compare to previous release][comp:1.0.0-rc.1]</small>
+
+>ℹ️ This is the first release candidate for the package. There should be minimal changes between this and the final v1.0.0 release - as such, this is considered production ready
 
 ### Breaking Changes (Overview)
 
@@ -338,6 +342,8 @@ All notable changes to this project will be documented in this file.
 
 **Initial release**
 
+[1.0.0-rc.1]: https://github.com/TopMarksDevelopment/Expression-Builder/releases/tag/v1.0.0-rc.1
+[comp:1.0.0-rc.1]: https://github.com/TopMarksDevelopment/Expression-Builder/compare/v0.4.0-beta...v1.0.0-rc.1
 [0.4.0-beta]: https://github.com/TopMarksDevelopment/Expression-Builder/releases/tag/v0.4.0-beta
 [comp:0.4.0-beta]: https://github.com/TopMarksDevelopment/Expression-Builder/compare/v0.3.0-beta...v0.4.0-beta
 [0.3.0-beta]: https://github.com/TopMarksDevelopment/Expression-Builder/releases/tag/v0.3.0-beta

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -29,7 +29,7 @@ All notable changes to this project will be documented in this file.
 
 <small>[Compare to previous release][comp:1.0.0-rc.1]</small>
 
->ℹ️ This is the first release candidate for the package. There should be minimal changes between this and the final v1.0.0 release - as such, this is considered production ready
+>&#x1F6C8; This is the first release candidate for the package. There should be minimal changes between this and the final v1.0.0 release - as such, this is considered production ready
 
 ### Breaking Changes (Overview)
 

--- a/Packages/Api/src/Api.Src.csproj
+++ b/Packages/Api/src/Api.Src.csproj
@@ -8,7 +8,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Api</PackageId>
-    <version>0.4.0-beta</version>
+    <version>1.0.0-rc.1</version>
     <title>Expression Builder (API)</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Core/src/Core.Src.csproj
+++ b/Packages/Core/src/Core.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Core</PackageId>
-    <version>0.4.0-beta</version>
+    <version>1.0.0-rc.1</version>
     <title>Expression Builder (Core Functionality)</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Main/src/Main.Src.csproj
+++ b/Packages/Main/src/Main.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder</PackageId>
-    <version>0.4.0-beta</version>
+    <version>1.0.0-rc.1</version>
     <title>Expression Builder</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/Between/src/Operations.Between.Src.csproj
+++ b/Packages/Operations/Between/src/Operations.Between.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.Between</PackageId>
-    <version>0.4.0-beta</version>
+    <version>1.0.0-rc.1</version>
     <title>Expression Builder - Operation: Between</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/BetweenExclusive/src/Operations.BetweenExclusive.Src.csproj
+++ b/Packages/Operations/BetweenExclusive/src/Operations.BetweenExclusive.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.BetweenExclusive</PackageId>
-    <version>0.4.0-beta</version>
+    <version>1.0.0-rc.1</version>
     <title>Expression Builder - Operation: BetweenExclusive</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/Contains/src/Operations.Contains.Src.csproj
+++ b/Packages/Operations/Contains/src/Operations.Contains.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.Contains</PackageId>
-    <version>0.4.0-beta</version>
+    <version>1.0.0-rc.1</version>
     <title>Expression Builder - Operation: Contains</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/DoesNotContain/src/Operations.DoesNotContain.Src.csproj
+++ b/Packages/Operations/DoesNotContain/src/Operations.DoesNotContain.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.DoesNotContain</PackageId>
-    <version>0.4.0-beta</version>
+    <version>1.0.0-rc.1</version>
     <title>Expression Builder - Operation: DoesNotContain</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/DoesNotEndWith/src/Operations.DoesNotEndWith.Src.csproj
+++ b/Packages/Operations/DoesNotEndWith/src/Operations.DoesNotEndWith.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.DoesNotEndWith</PackageId>
-    <version>0.4.0-beta</version>
+    <version>1.0.0-rc.1</version>
     <title>Expression Builder - Operation: DoesNotEndWith</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/DoesNotStartWith/src/Operations.DoesNotStartWith.Src.csproj
+++ b/Packages/Operations/DoesNotStartWith/src/Operations.DoesNotStartWith.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.DoesNotStartWith</PackageId>
-    <version>0.4.0-beta</version>
+    <version>1.0.0-rc.1</version>
     <title>Expression Builder - Operation: DoesNotStartWith</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/EndsWith/src/Operations.EndsWith.Src.csproj
+++ b/Packages/Operations/EndsWith/src/Operations.EndsWith.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.EndsWith</PackageId>
-    <version>0.4.0-beta</version>
+    <version>1.0.0-rc.1</version>
     <title>Expression Builder - Operation: EndsWith</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/Equal/src/Operations.Equal.Src.csproj
+++ b/Packages/Operations/Equal/src/Operations.Equal.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.Equal</PackageId>
-    <version>0.4.0-beta</version>
+    <version>1.0.0-rc.1</version>
     <title>Expression Builder - Operation: Equal</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/GreaterThan/src/Operations.GreaterThan.Src.csproj
+++ b/Packages/Operations/GreaterThan/src/Operations.GreaterThan.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.GreaterThan</PackageId>
-    <version>0.4.0-beta</version>
+    <version>1.0.0-rc.1</version>
     <title>Expression Builder - Operation: GreaterThan</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/GreaterThanOrEqual/src/Operations.GreaterThanOrEqual.Src.csproj
+++ b/Packages/Operations/GreaterThanOrEqual/src/Operations.GreaterThanOrEqual.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.GreaterThanOrEqual</PackageId>
-    <version>0.4.0-beta</version>
+    <version>1.0.0-rc.1</version>
     <title>Expression Builder - Operation: GreaterThanOrEqual</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/In/src/Operations.In.Src.csproj
+++ b/Packages/Operations/In/src/Operations.In.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.In</PackageId>
-    <version>0.4.0-beta</version>
+    <version>1.0.0-rc.1</version>
     <title>Expression Builder - Operation: In</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/IsEmpty/src/Operations.IsEmpty.Src.csproj
+++ b/Packages/Operations/IsEmpty/src/Operations.IsEmpty.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.IsEmpty</PackageId>
-    <version>0.4.0-beta</version>
+    <version>1.0.0-rc.1</version>
     <title>Expression Builder - Operation: IsEmpty</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/IsNotEmpty/src/Operations.IsNotEmpty.Src.csproj
+++ b/Packages/Operations/IsNotEmpty/src/Operations.IsNotEmpty.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.IsNotEmpty</PackageId>
-    <version>0.4.0-beta</version>
+    <version>1.0.0-rc.1</version>
     <title>Expression Builder - Operation: IsNotEmpty</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/IsNotNull/src/Operations.IsNotNull.Src.csproj
+++ b/Packages/Operations/IsNotNull/src/Operations.IsNotNull.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.IsNotNull</PackageId>
-    <version>0.4.0-beta</version>
+    <version>1.0.0-rc.1</version>
     <title>Expression Builder - Operation: IsNotNull</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/IsNotNullOrWhiteSpace/src/Operations.IsNotNullOrWhiteSpace.Src.csproj
+++ b/Packages/Operations/IsNotNullOrWhiteSpace/src/Operations.IsNotNullOrWhiteSpace.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.IsNotNullOrWhiteSpace</PackageId>
-    <version>0.4.0-beta</version>
+    <version>1.0.0-rc.1</version>
     <title>Expression Builder - Operation: IsNotNullOrWhiteSpace</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/IsNull/src/Operations.IsNull.Src.csproj
+++ b/Packages/Operations/IsNull/src/Operations.IsNull.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.IsNull</PackageId>
-    <version>0.4.0-beta</version>
+    <version>1.0.0-rc.1</version>
     <title>Expression Builder - Operation: IsNull</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/IsNullOrWhiteSpace/src/Operations.IsNullOrWhiteSpace.Src.csproj
+++ b/Packages/Operations/IsNullOrWhiteSpace/src/Operations.IsNullOrWhiteSpace.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.IsNullOrWhiteSpace</PackageId>
-    <version>0.4.0-beta</version>
+    <version>1.0.0-rc.1</version>
     <title>Expression Builder - Operation: IsNullOrWhiteSpace</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/LessThan/src/Operations.LessThan.Src.csproj
+++ b/Packages/Operations/LessThan/src/Operations.LessThan.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.LessThan</PackageId>
-    <version>0.4.0-beta</version>
+    <version>1.0.0-rc.1</version>
     <title>Expression Builder - Operation: LessThan</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/LessThanOrEqual/src/Operations.LessThanOrEqual.Src.csproj
+++ b/Packages/Operations/LessThanOrEqual/src/Operations.LessThanOrEqual.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.LessThanOrEqual</PackageId>
-    <version>0.4.0-beta</version>
+    <version>1.0.0-rc.1</version>
     <title>Expression Builder - Operation: LessThanOrEqual</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/NotBetween/src/Operations.NotBetween.Src.csproj
+++ b/Packages/Operations/NotBetween/src/Operations.NotBetween.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.NotBetween</PackageId>
-    <version>0.4.0-beta</version>
+    <version>1.0.0-rc.1</version>
     <title>Expression Builder - Operation: NotBetween</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/NotBetweenExclusive/src/Operations.NotBetweenExclusive.Src.csproj
+++ b/Packages/Operations/NotBetweenExclusive/src/Operations.NotBetweenExclusive.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.NotBetweenExclusive</PackageId>
-    <version>0.4.0-beta</version>
+    <version>1.0.0-rc.1</version>
     <title>Expression Builder - Operation: NotBetweenExclusive</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/NotEqual/src/Operations.NotEqual.Src.csproj
+++ b/Packages/Operations/NotEqual/src/Operations.NotEqual.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.NotEqual</PackageId>
-    <version>0.4.0-beta</version>
+    <version>1.0.0-rc.1</version>
     <title>Expression Builder - Operation: NotEqual</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/NotIn/src/Operations.NotIn.Src.csproj
+++ b/Packages/Operations/NotIn/src/Operations.NotIn.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.NotIn</PackageId>
-    <version>0.4.0-beta</version>
+    <version>1.0.0-rc.1</version>
     <title>Expression Builder - Operation: NotIn</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/SmartSearch/src/Operations.SmartSearch.Src.csproj
+++ b/Packages/Operations/SmartSearch/src/Operations.SmartSearch.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.SmartSearch</PackageId>
-    <version>0.4.0-beta</version>
+    <version>1.0.0-rc.1</version>
     <title>Expression Builder - Operation: SmartSearch</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>

--- a/Packages/Operations/StartsWith/src/Operations.StartsWith.Src.csproj
+++ b/Packages/Operations/StartsWith/src/Operations.StartsWith.Src.csproj
@@ -7,7 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <PackageId>TopMarksDevelopment.ExpressionBuilder.Operations.StartsWith</PackageId>
-    <version>0.4.0-beta</version>
+    <version>1.0.0-rc.1</version>
     <title>Expression Builder - Operation: StartsWith</title>
     <Authors>Glenn Marks</Authors>
     <Company>Top Marks Development</Company>


### PR DESCRIPTION
# 1.0.0-rc.1 - 2024-09-19

<small>[Compare to previous release][comp:1.0.0-rc.1]</small>

>&#x1F6C8; This is the first release candidate for the package. There should be minimal changes between this and the final v1.0.0 release - as such, this is considered production ready

### Breaking Changes (Overview)

-   `byte[]` and stream serialisation has changed, but is now significantly more robust (and simpler in its' implementation)
    -   As JSON filtering hasn't changed, you can retain any filters saved in `byte[]` form. Before upgrading convert them to JSON and then upgrade and revert them back
    -   Linked to this; `TypeTracker.DefaultFilterStatementTypes` has also been removed, as it is no longer required for serialisation

### Changes (Overview)

-   Formatted across the whole project
-   Removed unused/unnecessary `using` statements

### Package: TopMarksDevelopment.ExpressionBuilder.Api

#### Breaking Changes

-   `IFilterCollection`/`IFilterCollection<T?>` now expects an `AddRange` method

#### Added

-   Finally added all summary blocks 🎉
    (Chore: do the same to all other packages)

### Package: TopMarksDevelopment.ExpressionBuilder.Core

#### Breaking Changes

-   `byte[]` and stream serialisation has changed, but is now significantly more robust
    -   As JSON filtering hasn't changed, you can retain any filters saved in `byte[]` form. Before upgrading convert them to JSON and then upgrade and revert them back
    -   Linked to this; `TypeTracker.DefaultFilterStatementTypes` has also been removed, as it is no longer required for serialisation

#### Added

-   There's now a `.proto` file available [here](./Packages/Core/src/Proto/ExpressionBuilder.proto)
-   `FilterCollection` and `FilterCollection<T?>` include an `AddRange` method - supporting API Changes
-   Added new members for the serialisation changes
    -   `IProtoFilterItem` interface
        Used on classes that build our filter (implementing the conversion between types)
    -   `IProtoConverter` interface
        When your generic type is not a supported value, implementing this interface means we can still process it in `byte[]` serialisation
    -   `ProtoFilterStatement` class
        The new class used for `byte[]` serialisation. This class does not have a generic type, so makes serialising a lot more simple and robust

#### Changes

-   Added JSON file test and renamed JSON tests
-   Removed tests associated with `TypeTracker.DefaultFilterStatementTypes` work

[comp:1.0.0-rc.1]: https://github.com/TopMarksDevelopment/Expression-Builder/compare/v0.4.0-beta...v1.0.0-rc.1